### PR TITLE
Make fauxfactory installable via pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ develop-eggs
 lib
 lib64
 __pycache__
+MANIFEST
 
 # Installer logs
 pip-log.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.rst
+include LICENSE

--- a/README.md
+++ b/README.md
@@ -1,7 +1,0 @@
-# FauxFactory [![Build Status](https://travis-ci.org/omaciel/fauxfactory.png?branch=master)](https://travis-ci.org/omaciel/fauxfactory)
-
-Full documentation coming soon!
-
-## About
-
-Generates random data for your tests.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,12 @@
+FauxFactory
+===========
+
+.. image:: https://travis-ci.org/omaciel/fauxfactory.png?branch=master
+    :target: https://travis-ci.org/omaciel/fauxfactory
+
+Full documentation coming soon!
+
+About
+-----
+
+Generates random data for your tests.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from distutils.core import setup
+
+with open('README.rst') as file:
+    long_description = file.read()
+
+setup(
+    name='fauxfactory',
+    version='0.1.0',
+    url='https://github.com/omaciel/fauxfactory',
+    author='Og Maciel',
+    author_email='omaciel@redhat.com',
+    packages=['fauxfactory'],
+    long_description=long_description,
+)


### PR DESCRIPTION
Obs.: Changed the README to rst format to allow PyPi parse it.
