### PR TITLE
[DONOTMERGE] generate_email uses production domains.

### DIFF
--- a/fauxfactory/constants.py
+++ b/fauxfactory/constants.py
@@ -30,14 +30,13 @@ SCHEMES = [
 
 SUBDOMAINS = [
     'example',
+    'invalid',
+    'localhost',
     'test',
 ]
 
 TLDS = [
-    'biz',
     'com',
-    'edu',
-    'gov',
-    'info',
+    'net',
     'org',
 ]


### PR DESCRIPTION
This fixes issue #26.
