### PR TITLE
Enable sphinx.ext.doctest, make other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Documentation artifacts
+/docs/_build/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ import os
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
     'sphinx.ext.viewcode',
 ]
 
@@ -130,7 +131,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,28 +1,53 @@
 Getting Started
-====================
+===============
+
+.. testsetup::
+
+    import os
+    import sys
+    ROOT_PATH = os.path.abspath(os.path.pardir)
+    if ROOT_PATH not in sys.path:
+        sys.path.append(ROOT_PATH)
+    from fauxfactory import FauxFactory
 
 FauxFactory generates random data for your automated tests easily!
 
-Need a 10 characters string for one of your tests? ::
+Need a 10 characters string for one of your tests?
 
-    >>>FauxFacotry.generate_string('alphanumeric', 10)
-    fkQcdGGfH1
+.. doctest::
 
-Need a 5 character numeric string? ::
+    >>> string = FauxFactory.generate_string('alphanumeric', 10)
+    >>> string.isalnum()
+    True
+    >>> len(string)
+    10
 
-    >>>FauxFactory.generate_string('numeric', 5)
-    14354
+Need a 5 character numeric string?
 
-Now, let's say you need a random date ::
+.. doctest::
 
-    >>>FauxFactory.generate_date()
-    2972-02-26
+    >>> string = FauxFactory.generate_string('numeric', 5)
+    >>> string.isnumeric()
+    True
+    >>> len(string)
+    5
 
-and a fake email with your company domain ::
+Now, let's say you need a random date:
 
-    >>>FauxFactory.generate_email(domain="mycompany")
-    ZniSxAvb@mycompany.com
+.. doctest::
+
+    >>> import datetime
+    >>> isinstance(FauxFactory.generate_date(), datetime.date)
+    True
+    >>> isinstance(FauxFactory.generate_datetime(), datetime.datetime)
+    True
+
+Or a fake email with your company domain:
+
+.. doctest::
+
+    >>> email = FauxFactory.generate_email(domain='mycompany')
+    >>> '@mycompany' in email
+    True
 
 Simple, right?
-
-|

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 FauxFactory's Documentation
-=======================================
+===========================
 
 FauxFactory generates random data for your automated tests easily!
 
@@ -8,4 +8,4 @@ FauxFactory generates random data for your automated tests easily!
 
     installation
     getting_started
-    methods_available   
+    methods_available

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,12 +4,13 @@ Installation
 Python Package Index
 --------------------
 FauxFactory is available in PYPI and can be installed using pip::
-    
+
     $ pip install fauxfactory
 
-From source
+From Source
 -----------
-You can install FauxFactory by downloading the latest version of the source code::
+You can install FauxFactory by downloading the latest version of the source
+code::
 
     $ git clone git@github.com:omaciel/fauxfactory.git
     $ cd fauxfactory

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -586,5 +586,3 @@ class TestStrings(unittest.TestCase):
         numeric_string = self.factory.generate_string('numeric', 20)
         self.assertEqual(20, len(numeric_string),
                          "Generated string does not have the expected length")
-
-


### PR DESCRIPTION
In `docs/conf.py`, enable the "doctest" extension. This allows the `make
doctest` command to be used. Rewrite `docs/getting_started.rst` to make use of
the extension.

Make git ignore documentation build artifacts.

Comment out the unused `html_static_path` option from `docs/conf.py`. It was
causing a warning when `make html` was executed.

Clean up some other minor stuff. Properly wrap lines at 80 chars wide, remove
some spurious blank lines, remove trailing whitespace.
