### PR TITLE
More thoroughly test method generate_html

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 - Elyézer Rezende `@elyezer <https://github.com/elyezer/>`_
 - Jefferson Fausto Vaz `@faustovaz <https://github.com/faustovaz/>`_
 - Jeremy Audet `@Ichimonji10 <https://github.com/Ichimonji10/>`_
+- Kedar Bidarkar  `@kbidarkar <https://github.com/kbidarkar/>`_


### PR DESCRIPTION
Create a battery of three tests for method `generate_html`. These tests check
that:
- The string returned is unicode.
- If the `length` argument is omitted, the contents of the returned HTML tag are
  at least one character long.
- If the `length` argument is provided, the contents of the returned HTML tag are
  of the provided length.

Fixes #33.
