### PR TITLE
Do not instantiate FauxFactory

### DIFF
--- a/tests/test_booleans.py
+++ b/tests/test_booleans.py
@@ -14,14 +14,6 @@ class TestBooleans(unittest.TestCase):
     Test boolean generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_boolean_1(self):
         """
         @Test: Create a random boolean value
@@ -30,6 +22,6 @@ class TestBooleans(unittest.TestCase):
         """
 
         for turn in range(100):
-            result = self.factory.generate_boolean()
+            result = FauxFactory.generate_boolean()
             self.assertIsInstance(result, bool,
                                   "A valid boolean value was not generated.")

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -15,14 +15,6 @@ class TestChoices(unittest.TestCase):
     Test choices generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_choice_1(self):
         """
         @Test: Select a random value from integer values
@@ -33,7 +25,7 @@ class TestChoices(unittest.TestCase):
         choices = range(5)
 
         for turn in range(10):
-            result = self.factory.generate_choice(choices)
+            result = FauxFactory.generate_choice(choices)
             self.assertIn(
                 result,
                 choices,
@@ -49,7 +41,7 @@ class TestChoices(unittest.TestCase):
         choices = string.ascii_letters + string.digits
 
         for turn in range(10):
-            result = self.factory.generate_choice(choices)
+            result = FauxFactory.generate_choice(choices)
             self.assertIn(
                 result,
                 choices,
@@ -65,7 +57,7 @@ class TestChoices(unittest.TestCase):
         choices = [1, ]
 
         for turn in range(10):
-            result = self.factory.generate_choice(choices)
+            result = FauxFactory.generate_choice(choices)
             self.assertEqual(
                 result,
                 choices[0],
@@ -81,7 +73,7 @@ class TestChoices(unittest.TestCase):
         choices = [1, 2, 3, 9, 10, 11, 100, 101, 102]
 
         for turn in range(10):
-            result = self.factory.generate_choice(choices)
+            result = FauxFactory.generate_choice(choices)
             self.assertIn(
                 result,
                 choices,
@@ -97,7 +89,7 @@ class TestChoices(unittest.TestCase):
         choices = (1, )
 
         for turn in range(10):
-            result = self.factory.generate_choice(choices)
+            result = FauxFactory.generate_choice(choices)
             self.assertEqual(
                 result,
                 choices[0],
@@ -113,7 +105,7 @@ class TestChoices(unittest.TestCase):
         choices = (1, 2, 3, 9, 10, 11, 100, 101, 102, )
 
         for turn in range(10):
-            result = self.factory.generate_choice(choices)
+            result = FauxFactory.generate_choice(choices)
             self.assertIn(
                 result,
                 choices,
@@ -129,7 +121,7 @@ class TestChoices(unittest.TestCase):
         choices = []
 
         with self.assertRaises(ValueError):
-            self.factory.generate_choice(choices)
+            FauxFactory.generate_choice(choices)
 
     def test_generate_choice_8(self):
         """
@@ -141,7 +133,7 @@ class TestChoices(unittest.TestCase):
         choices = ()
 
         with self.assertRaises(ValueError):
-            self.factory.generate_choice(choices)
+            FauxFactory.generate_choice(choices)
 
     def test_generate_choice_9(self):
         """
@@ -153,7 +145,7 @@ class TestChoices(unittest.TestCase):
         choices = {}
 
         with self.assertRaises(ValueError):
-            self.factory.generate_choice(choices)
+            FauxFactory.generate_choice(choices)
 
     def test_generate_choice_10(self):
         """
@@ -165,7 +157,7 @@ class TestChoices(unittest.TestCase):
         choices = {'Name': 'Bob', 'Age': 39}
 
         with self.assertRaises(ValueError):
-            self.factory.generate_choice(choices)
+            FauxFactory.generate_choice(choices)
 
     def test_generate_choice_11(self):
         """
@@ -181,7 +173,7 @@ class TestChoices(unittest.TestCase):
         ]
 
         for turn in range(10):
-            result = self.factory.generate_choice(choices)
+            result = FauxFactory.generate_choice(choices)
             self.assertIn(
                 result,
                 choices,
@@ -197,7 +189,7 @@ class TestChoices(unittest.TestCase):
         choices = ['green', 'yellow', 'blue' 'white']
 
         for turn in range(10):
-            result = self.factory.generate_choice(choices)
+            result = FauxFactory.generate_choice(choices)
             self.assertIn(
                 result,
                 choices,
@@ -213,4 +205,4 @@ class TestChoices(unittest.TestCase):
         choices = None
 
         with self.assertRaises(ValueError):
-            self.factory.generate_choice(choices)
+            FauxFactory.generate_choice(choices)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -16,21 +16,13 @@ class TestDates(unittest.TestCase):
     Test date generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_date_1(self):
         """
         @Test: Create a date with no arguments
         @Feature: Date Generator
         @Assert: Date is created with random values.
         """
-        result = self.factory.generate_date()
+        result = FauxFactory.generate_date()
         self.assertTrue(
             isinstance(result, datetime.date),
             "Data is not instance of datetime.date.")
@@ -48,7 +40,7 @@ class TestDates(unittest.TestCase):
         min_date = today - datetime.timedelta(5)
 
         for turn in range(10):
-            result = self.factory.generate_date(min_date=min_date)
+            result = FauxFactory.generate_date(min_date=min_date)
             self.assertTrue(result >= min_date)
 
     def test_generate_date_3(self):
@@ -64,7 +56,7 @@ class TestDates(unittest.TestCase):
         max_date = today + datetime.timedelta(5)
 
         for turn in range(10):
-            result = self.factory.generate_date(max_date=max_date)
+            result = FauxFactory.generate_date(max_date=max_date)
             self.assertTrue(result <= max_date)
 
     def test_generate_date_4(self):
@@ -82,7 +74,7 @@ class TestDates(unittest.TestCase):
         max_date = today + datetime.timedelta(5)
 
         for turn in range(10):
-            result = self.factory.generate_date(
+            result = FauxFactory.generate_date(
                 min_date=min_date,
                 max_date=max_date
             )
@@ -103,7 +95,7 @@ class TestDates(unittest.TestCase):
         max_date = min_date + datetime.timedelta(365 * 1)
 
         for turn in range(20):
-            result = self.factory.generate_date(
+            result = FauxFactory.generate_date(
                 min_date=None,
                 max_date=max_date
             )
@@ -124,7 +116,7 @@ class TestDates(unittest.TestCase):
         min_date = max_date - datetime.timedelta(365 * 1)
 
         for turn in range(20):
-            result = self.factory.generate_date(
+            result = FauxFactory.generate_date(
                 min_date=min_date,
                 max_date=None
             )
@@ -146,7 +138,7 @@ class TestDates(unittest.TestCase):
                     datetime.timedelta(365 * MAX_YEARS))
 
         for turn in range(20):
-            result = self.factory.generate_date(
+            result = FauxFactory.generate_date(
                 min_date=min_date,
                 max_date=max_date
             )
@@ -161,7 +153,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_date(
+            FauxFactory.generate_date(
                 min_date='',
                 max_date=''
             )
@@ -174,7 +166,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_date(
+            FauxFactory.generate_date(
                 min_date='abc',
                 max_date='def'
             )
@@ -187,7 +179,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_date(
+            FauxFactory.generate_date(
                 min_date=1,
                 max_date=1
             )
@@ -200,7 +192,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_date(
+            FauxFactory.generate_date(
                 min_date=(1,),
                 max_date=(2, 3, 4)
             )
@@ -213,7 +205,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_date(
+            FauxFactory.generate_date(
                 min_date=['a', 'b'],
                 max_date=['c', 'd', 'e']
             )
@@ -231,7 +223,7 @@ class TestDates(unittest.TestCase):
         min_date = today + datetime.timedelta(5)
 
         with self.assertRaises(AssertionError):
-            self.factory.generate_date(
+            FauxFactory.generate_date(
                 min_date=min_date,
                 max_date=today
             )
@@ -244,7 +236,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_date(
+            FauxFactory.generate_date(
                 min_date=datetime.date.today(),
                 max_date='foo'
             )

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -16,14 +16,6 @@ class TestDates(unittest.TestCase):
     Test datetime generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_datetime_1(self):
         """
         @Test: Create a datetime with no arguments
@@ -31,7 +23,7 @@ class TestDates(unittest.TestCase):
         @Assert: Datetime is created with random values
         """
 
-        result = self.factory.generate_datetime()
+        result = FauxFactory.generate_datetime()
         self.assertTrue(
             isinstance(result, datetime.datetime),
             "Data is not instance of datetime.date.")
@@ -49,7 +41,7 @@ class TestDates(unittest.TestCase):
         min_date = today - datetime.timedelta(seconds=5*60)
 
         for turn in range(10):
-            result = self.factory.generate_datetime(min_date=min_date)
+            result = FauxFactory.generate_datetime(min_date=min_date)
             self.assertTrue(result >= min_date)
 
     def test_generate_datetime_3(self):
@@ -65,7 +57,7 @@ class TestDates(unittest.TestCase):
         max_date = today + datetime.timedelta(seconds=5*60)
 
         for turn in range(10):
-            result = self.factory.generate_datetime(max_date=max_date)
+            result = FauxFactory.generate_datetime(max_date=max_date)
             self.assertTrue(result <= max_date)
 
     def test_generate_datetime_4(self):
@@ -83,7 +75,7 @@ class TestDates(unittest.TestCase):
         max_date = today + datetime.timedelta(seconds=5*60)
 
         for turn in range(10):
-            result = self.factory.generate_datetime(
+            result = FauxFactory.generate_datetime(
                 min_date=min_date,
                 max_date=max_date
             )
@@ -104,7 +96,7 @@ class TestDates(unittest.TestCase):
         max_date = min_date + datetime.timedelta(365 * 1)
 
         for turn in range(20):
-            result = self.factory.generate_datetime(
+            result = FauxFactory.generate_datetime(
                 min_date=None,
                 max_date=max_date
             )
@@ -125,7 +117,7 @@ class TestDates(unittest.TestCase):
         min_date = max_date - datetime.timedelta(365 * 1)
 
         for turn in range(20):
-            result = self.factory.generate_datetime(
+            result = FauxFactory.generate_datetime(
                 min_date=min_date,
                 max_date=None
             )
@@ -147,7 +139,7 @@ class TestDates(unittest.TestCase):
                     datetime.timedelta(365 * MAX_YEARS))
 
         for turn in range(20):
-            result = self.factory.generate_datetime(
+            result = FauxFactory.generate_datetime(
                 min_date=min_date,
                 max_date=max_date
             )
@@ -162,7 +154,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_datetime(
+            FauxFactory.generate_datetime(
                 min_date='',
                 max_date=''
             )
@@ -175,7 +167,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_datetime(
+            FauxFactory.generate_datetime(
                 min_date='abc',
                 max_date='def'
             )
@@ -188,7 +180,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_datetime(
+            FauxFactory.generate_datetime(
                 min_date=1,
                 max_date=1
             )
@@ -201,7 +193,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_datetime(
+            FauxFactory.generate_datetime(
                 min_date=(1,),
                 max_date=(2, 3, 4)
             )
@@ -214,7 +206,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_datetime(
+            FauxFactory.generate_datetime(
                 min_date=['a', 'b'],
                 max_date=['c', 'd', 'e']
             )
@@ -232,7 +224,7 @@ class TestDates(unittest.TestCase):
         min_date = today + datetime.timedelta(seconds=5*60)
 
         with self.assertRaises(AssertionError):
-            self.factory.generate_datetime(
+            FauxFactory.generate_datetime(
                 min_date=min_date,
                 max_date=today
             )
@@ -245,7 +237,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_date(
+            FauxFactory.generate_date(
                 min_date=datetime.datetime.now(),
                 max_date='foo'
             )

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -17,14 +17,6 @@ class TestEmails(unittest.TestCase):
     Test Email generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_email_1(self):
         """
         @Test: Create a random email value
@@ -35,7 +27,7 @@ class TestEmails(unittest.TestCase):
         # Regex for email validation
         emailinator = re.compile(REGEX)
         for turn in range(100):
-            result = self.factory.generate_email()
+            result = FauxFactory.generate_email()
 
             self.assertIsNotNone(emailinator.match(result),
                                  "A valid email value was not generated.")

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -18,13 +18,11 @@ class TestHTML(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """
-        Instantiate a factory and compile a regex.
+        """Instantiate a factory and compile a regex.
 
         The compiled regex can be used to find the contents of an HTML tag.
-        """
 
-        cls.factory = FauxFactory()
+        """
         cls.matcher = re.compile('^<.*?>(.*?)</.*>$')
 
     def test_length_arg_omitted(self):
@@ -35,7 +33,7 @@ class TestHTML(unittest.TestCase):
         @Assert: The contents of the HTML tag are at least one character long.
         """
 
-        match = self.matcher.search(self.factory.generate_html())
+        match = self.matcher.search(FauxFactory.generate_html())
         self.assertGreaterEqual(len(match.group(1)), 1)
 
     def test_length_arg_provided(self):
@@ -46,8 +44,8 @@ class TestHTML(unittest.TestCase):
         @Assert: The contents of the HTML tag are ``length`` characters long.
         """
 
-        length = self.factory.generate_integer(1, 25)
-        match = self.matcher.search(self.factory.generate_html(length))
+        length = FauxFactory.generate_integer(1, 25)
+        match = self.matcher.search(FauxFactory.generate_html(length))
         self.assertEqual(len(match.group(1)), length)
 
     def test_unicode(self):
@@ -57,7 +55,7 @@ class TestHTML(unittest.TestCase):
         @Assert: A unicode string is generated.
         """
 
-        result = self.factory.generate_html()
+        result = FauxFactory.generate_html()
         if sys.version_info[0] is 2:
             # (undefined-variable) pylint:disable=E0602
             self.assertIsInstance(result, unicode)  # flake8:noqa

--- a/tests/test_ipaddress.py
+++ b/tests/test_ipaddress.py
@@ -14,14 +14,6 @@ class TestIpaddr(unittest.TestCase):
     Test ipaddr generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_ipv4_1(self):
         """
         @Test: Generate a 3 group IPv4 address
@@ -30,7 +22,7 @@ class TestIpaddr(unittest.TestCase):
                  will always end with a \'.0\')
         """
 
-        result = self.factory.generate_ipaddr(ip3=True)
+        result = FauxFactory.generate_ipaddr(ip3=True)
         self.assertTrue(
             result.split(".")[-1] == '0',
             "Did not generate a 3-group IPv4 addrss")
@@ -42,7 +34,7 @@ class TestIpaddr(unittest.TestCase):
         @Assert: A 4-group IPv4 address is generated
         """
 
-        result = self.factory.generate_ipaddr()
+        result = FauxFactory.generate_ipaddr()
         self.assertTrue(
             len(result.split(".")) == 4,
             "Did not generate a 4-group IPv4 addrss")
@@ -54,7 +46,7 @@ class TestIpaddr(unittest.TestCase):
         @Assert: A 4-group IPv4 address is generated
         """
 
-        result = self.factory.generate_ipaddr(ip3=False)
+        result = FauxFactory.generate_ipaddr(ip3=False)
         self.assertTrue(
             len(result.split(".")) == 4,
             "Did not generate a 4-group IPv4 addrss")
@@ -66,7 +58,7 @@ class TestIpaddr(unittest.TestCase):
         @Assert: A 4-group IPv4 address is generated
         """
 
-        result = self.factory.generate_ipaddr(ip3=False, ipv6=False)
+        result = FauxFactory.generate_ipaddr(ip3=False, ipv6=False)
         self.assertTrue(
             len(result.split(".")) == 4,
             "Did not generate a 4-group IPv4 addrss")
@@ -78,7 +70,7 @@ class TestIpaddr(unittest.TestCase):
         @Assert: A IPv6 address is generated
         """
 
-        result = self.factory.generate_ipaddr(ipv6=True)
+        result = FauxFactory.generate_ipaddr(ipv6=True)
         self.assertTrue(
             len(result.split(":")) == 8,
             "Did not generate a IPv6 addrss")
@@ -90,7 +82,7 @@ class TestIpaddr(unittest.TestCase):
         @Assert: A IPv6 address is generated
         """
 
-        result = self.factory.generate_ipaddr(ip3=True, ipv6=True)
+        result = FauxFactory.generate_ipaddr(ip3=True, ipv6=True)
         self.assertTrue(
             len(result.split(":")) == 8,
             "Did not generate a IPv6 addrss")

--- a/tests/test_lorem_ipsum.py
+++ b/tests/test_lorem_ipsum.py
@@ -16,14 +16,6 @@ class TestLoremIpsum(unittest.TestCase):
     Test lorem ipsum generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_loremipsum_1(self):
         """
         @Test: Create a complete lorem ipsum string
@@ -31,7 +23,7 @@ class TestLoremIpsum(unittest.TestCase):
         @Assert: Complete lorem ipsum value that starts with 'Lorem ipsum'
         """
 
-        result = self.factory.generate_iplum()
+        result = FauxFactory.generate_iplum()
         self.assertEqual(
             result,
             LOREM_IPSUM_TEXT, "Generated text is not Lorem Ipsum")
@@ -49,7 +41,7 @@ class TestLoremIpsum(unittest.TestCase):
 
         for i in range(20):
             length = random.randint(1, 500)
-            result = self.factory.generate_iplum(words=length)
+            result = FauxFactory.generate_iplum(words=length)
             self.assertEqual(
                 len(result.split()),
                 length,
@@ -64,7 +56,7 @@ class TestLoremIpsum(unittest.TestCase):
 
         for i in range(20):
             length = random.randint(1, 20)
-            result = self.factory.generate_iplum(paragraphs=length)
+            result = FauxFactory.generate_iplum(paragraphs=length)
             self.assertEqual(
                 len(result.split('\n')),
                 length,
@@ -78,7 +70,7 @@ class TestLoremIpsum(unittest.TestCase):
         @Assert: Complete lorem ipsum value is returned
         """
 
-        result = self.factory.generate_iplum(words=0)
+        result = FauxFactory.generate_iplum(words=0)
         self.assertEqual(
             result,
             LOREM_IPSUM_TEXT, "Generated text is not Lorem Ipsum")
@@ -91,7 +83,7 @@ class TestLoremIpsum(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_iplum(paragraphs=0)
+            FauxFactory.generate_iplum(paragraphs=0)
 
     def test_generate_loremipsum_6(self):
         """
@@ -101,7 +93,7 @@ class TestLoremIpsum(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_iplum(words=1, paragraphs=0)
+            FauxFactory.generate_iplum(words=1, paragraphs=0)
 
     def test_generate_loremipsum_7(self):
         """
@@ -110,7 +102,7 @@ class TestLoremIpsum(unittest.TestCase):
         @Assert: Generated string has 1 word in 1 paragraph
         """
 
-        result = self.factory.generate_iplum(words=1, paragraphs=1)
+        result = FauxFactory.generate_iplum(words=1, paragraphs=1)
         self.assertEqual(len(result.split()), 1, "String is not 1-word long")
         self.assertEqual(
             len(result.split()), 1, "String is not 1-paragraph long")
@@ -123,7 +115,7 @@ class TestLoremIpsum(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_iplum(words='a')
+            FauxFactory.generate_iplum(words='a')
 
     def test_generate_loremipsum_9(self):
         """
@@ -133,7 +125,7 @@ class TestLoremIpsum(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_iplum(paragraphs='a')
+            FauxFactory.generate_iplum(paragraphs='a')
 
     def test_generate_loremipsum_10(self):
         """
@@ -145,7 +137,7 @@ class TestLoremIpsum(unittest.TestCase):
         for i in range(20):
             words = random.randint(1, 500)
             paragraphs = random.randint(1, 500)
-            result = self.factory.generate_iplum(
+            result = FauxFactory.generate_iplum(
                 words=words, paragraphs=paragraphs)
             self.assertEqual(
                 len(result.split('\n')),

--- a/tests/test_macs.py
+++ b/tests/test_macs.py
@@ -19,14 +19,6 @@ class TestMacs(unittest.TestCase):
     Test MAC generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_mac_1(self):
         """
         @Test: Generate a MAC address using \":\" as the delimiter
@@ -34,7 +26,7 @@ class TestMacs(unittest.TestCase):
         @Assert: A MAC address is generated using \":\" as the delimiter
         """
 
-        result = self.factory.generate_mac()
+        result = FauxFactory.generate_mac()
         self.assertTrue(
             len(result.split(":")) == 6,
             "Did not generate a MAC addrss")
@@ -49,7 +41,7 @@ class TestMacs(unittest.TestCase):
         @Assert: A MAC address is generated using \":\" as the delimiter
         """
 
-        result = self.factory.generate_mac(delimiter=":")
+        result = FauxFactory.generate_mac(delimiter=":")
         self.assertTrue(
             len(result.split(":")) == 6,
             "Did not generate a MAC addrss")
@@ -64,7 +56,7 @@ class TestMacs(unittest.TestCase):
         @Assert: A MAC address is generated using \"-\" as the delimiter
         """
 
-        result = self.factory.generate_mac(delimiter="-")
+        result = FauxFactory.generate_mac(delimiter="-")
         self.assertTrue(
             len(result.split("-")) == 6,
             "Did not generate a MAC addrss")
@@ -80,7 +72,7 @@ class TestMacs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_mac(delimiter=".")
+            FauxFactory.generate_mac(delimiter=".")
 
     def test_generate_mac_5(self):
         """
@@ -90,7 +82,7 @@ class TestMacs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_mac(delimiter=" ")
+            FauxFactory.generate_mac(delimiter=" ")
 
     def test_generate_mac_6(self):
         """
@@ -100,7 +92,7 @@ class TestMacs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_mac(delimiter=random.randint(0, 10))
+            FauxFactory.generate_mac(delimiter=random.randint(0, 10))
 
     def test_generate_mac_7(self):
         """
@@ -110,5 +102,5 @@ class TestMacs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_mac(
+            FauxFactory.generate_mac(
                 delimiter=random.choice(string.ascii_letters))

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -15,14 +15,6 @@ class TestNumbers(unittest.TestCase):
     Test number generators
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_integer_1(self):
         """
         @Test: Create a random integer with no range limits
@@ -30,7 +22,7 @@ class TestNumbers(unittest.TestCase):
         @Assert: A random integer is created
         """
 
-        result = self.factory.generate_integer()
+        result = FauxFactory.generate_integer()
         self.assertTrue(
             isinstance(result, int), "A valid integer was not generated.")
 
@@ -47,7 +39,7 @@ class TestNumbers(unittest.TestCase):
             sys.maxsize = 5
 
             for turn in range(10):
-                result = self.factory.generate_integer(min_value=1)
+                result = FauxFactory.generate_integer(min_value=1)
                 self.assertTrue(
                     result <= sys.maxsize, "Integer is greater than max_value"
                 )
@@ -72,7 +64,7 @@ class TestNumbers(unittest.TestCase):
             min_value = - sys.maxsize - 1
 
             for turn in range(10):
-                result = self.factory.generate_integer(max_value=1)
+                result = FauxFactory.generate_integer(max_value=1)
                 self.assertTrue(
                     result >= min_value, "Integer is less than min_value"
                 )
@@ -91,7 +83,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = self.factory.generate_integer(
+            result = FauxFactory.generate_integer(
                 min_value=1, max_value=3)
             self.assertTrue(
                 result >= 1, "Integer is less than min_value"
@@ -111,7 +103,7 @@ class TestNumbers(unittest.TestCase):
         low_min = - sys.maxsize - 2
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(min_value=low_min)
+            FauxFactory.generate_integer(min_value=low_min)
 
     def test_generate_integer_6(self):
         """
@@ -124,7 +116,7 @@ class TestNumbers(unittest.TestCase):
         high_max = sys.maxsize + 1
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(max_value=high_max)
+            FauxFactory.generate_integer(max_value=high_max)
 
     def test_generate_integer_7_0(self):
         """
@@ -134,7 +126,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(min_value='')
+            FauxFactory.generate_integer(min_value='')
 
     def test_generate_integer_7_1(self):
         """
@@ -144,7 +136,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(max_value='')
+            FauxFactory.generate_integer(max_value='')
 
     def test_generate_integer_7_2(self):
         """
@@ -154,7 +146,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(min_value='', max_value='')
+            FauxFactory.generate_integer(min_value='', max_value='')
 
     def test_generate_integer_8_0(self):
         """
@@ -164,7 +156,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(min_value=' ')
+            FauxFactory.generate_integer(min_value=' ')
 
     def test_generate_integer_8_1(self):
         """
@@ -174,7 +166,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(max_value=' ')
+            FauxFactory.generate_integer(max_value=' ')
 
     def test_generate_integer_8_2(self):
         """
@@ -184,7 +176,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(min_value=' ', max_value=' ')
+            FauxFactory.generate_integer(min_value=' ', max_value=' ')
 
     def test_generate_integer_9_0(self):
         """
@@ -194,7 +186,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(min_value='a')
+            FauxFactory.generate_integer(min_value='a')
 
     def test_generate_integer_9_1(self):
         """
@@ -204,7 +196,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(max_value='a')
+            FauxFactory.generate_integer(max_value='a')
 
     def test_generate_integer_9_2(self):
         """
@@ -214,7 +206,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_integer(min_value='a', max_value='b')
+            FauxFactory.generate_integer(min_value='a', max_value='b')
 
     def test_generate_positive_integer_1(self):
         """
@@ -223,7 +215,7 @@ class TestNumbers(unittest.TestCase):
         @Assert: A positive number is created
         """
 
-        result = self.factory.generate_positive_integer()
+        result = FauxFactory.generate_positive_integer()
 
         self.assertTrue(result >= 0, "Generated integer is not positive")
 
@@ -234,6 +226,6 @@ class TestNumbers(unittest.TestCase):
         @Assert: A negative number is created
         """
 
-        result = self.factory.generate_negative_integer()
+        result = FauxFactory.generate_negative_integer()
 
         self.assertTrue(result <= 0, "Generated integer is not negative")

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -16,14 +16,6 @@ class TestStrings(unittest.TestCase):
     Test string generators
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_alpha_1(self):
         """
         @Test: Create alpha string of varied length
@@ -31,7 +23,7 @@ class TestStrings(unittest.TestCase):
         @Assert: Alpha string is created
         """
 
-        result = self.factory.generate_alpha()
+        result = FauxFactory.generate_alpha()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
@@ -43,7 +35,7 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = self.factory.generate_alpha(length)
+            result = FauxFactory.generate_alpha(length)
             self.assertEqual(
                 len(result),
                 length,
@@ -57,7 +49,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alpha(length=0)
+            FauxFactory.generate_alpha(length=0)
 
     def test_generate_alpha_3_1(self):
         """
@@ -67,7 +59,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alphanumeric(length=0)
+            FauxFactory.generate_alphanumeric(length=0)
 
     def test_generate_alpha_3_2(self):
         """
@@ -77,7 +69,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_cjk(length=0)
+            FauxFactory.generate_cjk(length=0)
 
     def test_generate_alpha_3_3(self):
         """
@@ -87,7 +79,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_latin1(length=0)
+            FauxFactory.generate_latin1(length=0)
 
     def test_generate_alpha_3_4(self):
         """
@@ -97,7 +89,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_numeric_string(length=0)
+            FauxFactory.generate_numeric_string(length=0)
 
     def test_generate_alpha_4(self):
         """
@@ -107,7 +99,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alpha(length=-1)
+            FauxFactory.generate_alpha(length=-1)
 
     def test_generate_alpha_5(self):
         """
@@ -117,7 +109,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alpha(length=None)
+            FauxFactory.generate_alpha(length=None)
 
     def test_generate_alpha_6(self):
         """
@@ -127,7 +119,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alpha(length='')
+            FauxFactory.generate_alpha(length='')
 
     def test_generate_alpha_7(self):
         """
@@ -137,7 +129,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alpha(length=' ')
+            FauxFactory.generate_alpha(length=' ')
 
     def test_generate_alpha_8(self):
         """
@@ -147,7 +139,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alpha(length='a')
+            FauxFactory.generate_alpha(length='a')
 
     def test_generate_alpha_9(self):
         """
@@ -156,7 +148,7 @@ class TestStrings(unittest.TestCase):
         @Assert: Alpha string is created
         """
 
-        result = self.factory.generate_string('alpha', 15)
+        result = FauxFactory.generate_string('alpha', 15)
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
@@ -167,7 +159,7 @@ class TestStrings(unittest.TestCase):
         @Assert: Alphanumeric string is generated
         """
 
-        result = self.factory.generate_alphanumeric()
+        result = FauxFactory.generate_alphanumeric()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
@@ -179,7 +171,7 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = self.factory.generate_alphanumeric(length)
+            result = FauxFactory.generate_alphanumeric(length)
             self.assertEqual(
                 len(result),
                 length,
@@ -193,7 +185,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alphanumeric(length=0)
+            FauxFactory.generate_alphanumeric(length=0)
 
     def test_generate_alphanumeric_4(self):
         """
@@ -203,7 +195,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alphanumeric(length=-1)
+            FauxFactory.generate_alphanumeric(length=-1)
 
     def test_generate_alphanumeric_5(self):
         """
@@ -213,7 +205,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alphanumeric(length=None)
+            FauxFactory.generate_alphanumeric(length=None)
 
     def test_generate_alphanumeric_6(self):
         """
@@ -223,7 +215,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alphanumeric(length='')
+            FauxFactory.generate_alphanumeric(length='')
 
     def test_generate_alphanumeric_7(self):
         """
@@ -233,7 +225,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alphanumeric(length=' ')
+            FauxFactory.generate_alphanumeric(length=' ')
 
     def test_generate_alphanumeric_8(self):
         """
@@ -243,7 +235,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_alphanumeric(length='a')
+            FauxFactory.generate_alphanumeric(length='a')
 
     def test_generate_cjk_1(self):
         """
@@ -252,7 +244,7 @@ class TestStrings(unittest.TestCase):
         @Assert: CJK string is generated
         """
 
-        result = self.factory.generate_cjk()
+        result = FauxFactory.generate_cjk()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
@@ -264,7 +256,7 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = self.factory.generate_cjk(length)
+            result = FauxFactory.generate_cjk(length)
             self.assertEqual(
                 len(result),
                 length,
@@ -278,7 +270,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_cjk(length=0)
+            FauxFactory.generate_cjk(length=0)
 
     def test_generate_cjk_4(self):
         """
@@ -288,7 +280,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_cjk(length=-1)
+            FauxFactory.generate_cjk(length=-1)
 
     def test_generate_cjk_5(self):
         """
@@ -298,7 +290,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_cjk(length=None)
+            FauxFactory.generate_cjk(length=None)
 
     def test_generate_cjk_6(self):
         """
@@ -308,7 +300,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_cjk(length='')
+            FauxFactory.generate_cjk(length='')
 
     def test_generate_cjk_7(self):
         """
@@ -318,7 +310,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_cjk(length=' ')
+            FauxFactory.generate_cjk(length=' ')
 
     def test_generate_cjk_8(self):
         """
@@ -328,7 +320,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_cjk(length='a')
+            FauxFactory.generate_cjk(length='a')
 
     def test_generate_cjk_9(self):
         """
@@ -337,7 +329,7 @@ class TestStrings(unittest.TestCase):
         @Assert: CJK string is generated
         """
 
-        result = self.factory.generate_string('cjk', 15)
+        result = FauxFactory.generate_string('cjk', 15)
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
@@ -348,9 +340,9 @@ class TestStrings(unittest.TestCase):
         @Assert: A unicode string is generated.
         """
 
-        result = self.factory.generate_string('utf8', 5)
+        result = FauxFactory.generate_string('utf8', 5)
         if version_info[0] == 2:
-            self.assertTrue(isinstance(result, unicode))
+            self.assertTrue(isinstance(result, unicode))  # flake8:noqa
         else:
             self.assertTrue(isinstance(result, str))
 
@@ -363,7 +355,7 @@ class TestStrings(unittest.TestCase):
 
         length = random.randint(1, 100)
         self.assertEqual(
-            len(self.factory.generate_string('utf8', length)),
+            len(FauxFactory.generate_string('utf8', length)),
             length
         )
 
@@ -375,7 +367,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_string('utf8', 'foo')
+            FauxFactory.generate_string('utf8', 'foo')
 
     def test_generate_latin1_1(self):
         """
@@ -384,7 +376,7 @@ class TestStrings(unittest.TestCase):
         @Assert: Latin1 string is generated
         """
 
-        result = self.factory.generate_latin1()
+        result = FauxFactory.generate_latin1()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
@@ -396,7 +388,7 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = self.factory.generate_latin1(length)
+            result = FauxFactory.generate_latin1(length)
             self.assertEqual(
                 len(result),
                 length,
@@ -410,7 +402,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_latin1(length=0)
+            FauxFactory.generate_latin1(length=0)
 
     def test_generate_latin1_4(self):
         """
@@ -420,7 +412,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_latin1(length=-1)
+            FauxFactory.generate_latin1(length=-1)
 
     def test_generate_latin1_5(self):
         """
@@ -430,7 +422,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_latin1(length=None)
+            FauxFactory.generate_latin1(length=None)
 
     def test_generate_latin1_6(self):
         """
@@ -440,7 +432,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_latin1(length='')
+            FauxFactory.generate_latin1(length='')
 
     def test_generate_latin1_7(self):
         """
@@ -450,7 +442,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_latin1(length=' ')
+            FauxFactory.generate_latin1(length=' ')
 
     def test_generate_latin1_8(self):
         """
@@ -460,7 +452,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_latin1(length='a')
+            FauxFactory.generate_latin1(length='a')
 
     def test_generate_latin1_9(self):
         """
@@ -469,7 +461,7 @@ class TestStrings(unittest.TestCase):
         @Assert: Latin1 string is generated
         """
 
-        result = self.factory.generate_string('latin1', 15)
+        result = FauxFactory.generate_string('latin1', 15)
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
@@ -480,7 +472,7 @@ class TestStrings(unittest.TestCase):
         @Assert: Latin1 string is not created due to value error
         """
 
-        result = self.factory.generate_numeric_string()
+        result = FauxFactory.generate_numeric_string()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
@@ -492,7 +484,7 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = self.factory.generate_numeric_string(length)
+            result = FauxFactory.generate_numeric_string(length)
             self.assertEqual(
                 len(result),
                 length,
@@ -506,7 +498,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_numeric_string(length=0)
+            FauxFactory.generate_numeric_string(length=0)
 
     def test_generate_numeric_string_4(self):
         """
@@ -516,7 +508,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_numeric_string(length=-1)
+            FauxFactory.generate_numeric_string(length=-1)
 
     def test_generate_numeric_string_5(self):
         """
@@ -526,7 +518,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_numeric_string(length=None)
+            FauxFactory.generate_numeric_string(length=None)
 
     def test_generate_numeric_string_6(self):
         """
@@ -536,7 +528,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_numeric_string(length='')
+            FauxFactory.generate_numeric_string(length='')
 
     def test_generate_numeric_string_7(self):
         """
@@ -546,7 +538,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_numeric_string(length=' ')
+            FauxFactory.generate_numeric_string(length=' ')
 
     def test_generate_numeric_string_8(self):
         """
@@ -556,7 +548,7 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_numeric_string(length='a')
+            FauxFactory.generate_numeric_string(length='a')
 
     def test_generate_string(self):
         """
@@ -564,7 +556,7 @@ class TestStrings(unittest.TestCase):
         @Feature: String Generator
         @Assert: Alphanumeric string is created with size of 15 chars
         """
-        alphanumeric_string = self.factory.generate_string('alphanumeric', 15)
+        alphanumeric_string = FauxFactory.generate_string('alphanumeric', 15)
         self.assertEqual(15, len(alphanumeric_string),
                          "Generated string does not have the expected length")
 
@@ -575,7 +567,7 @@ class TestStrings(unittest.TestCase):
         @Assert: Alpha string is not created due to the lack of parameter type
         """
         with self.assertRaises(Exception):
-            self.factory.generate_string('', 15)
+            FauxFactory.generate_string('', 15)
 
     def test_generate_string3(self):
         """
@@ -583,7 +575,7 @@ class TestStrings(unittest.TestCase):
         @Feature: String generator
         @Assert: Numeric string is created with size of 20 chars
         """
-        numeric_string = self.factory.generate_string('numeric', 20)
+        numeric_string = FauxFactory.generate_string('numeric', 20)
         self.assertEqual(20, len(numeric_string),
                          "Generated string does not have the expected length")
 
@@ -593,6 +585,6 @@ class TestStrings(unittest.TestCase):
         @Feature: String generator
         @Assert: HTML string is created and should greater than given length
         """
-        html_string = self.factory.generate_string('html', 10)
+        html_string = FauxFactory.generate_string('html', 10)
         self.assertTrue(len(html_string) > 10,
                         "Generated string does not have the expected length")

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -15,14 +15,6 @@ class TestTime(unittest.TestCase):
     Test Time generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_uuid_1(self):
         """
         @Test: Create a random UUID value
@@ -31,6 +23,6 @@ class TestTime(unittest.TestCase):
         """
 
         for turn in range(100):
-            result = self.factory.generate_time()
+            result = FauxFactory.generate_time()
             self.assertIsInstance(result, datetime.time,
                                   "A valid Time value was not generated.")

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -15,14 +15,6 @@ class TestURLs(unittest.TestCase):
     Test URL generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_url_1(self):
         """
         @Test: Create a random URL
@@ -31,7 +23,7 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = self.factory.generate_url()
+            result = FauxFactory.generate_url()
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -48,7 +40,7 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = self.factory.generate_url(scheme='http')
+            result = FauxFactory.generate_url(scheme='http')
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -65,7 +57,7 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = self.factory.generate_url(scheme='https')
+            result = FauxFactory.generate_url(scheme='https')
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -82,7 +74,7 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = self.factory.generate_url(scheme='ftp')
+            result = FauxFactory.generate_url(scheme='ftp')
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -99,9 +91,9 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            scheme = self.factory.generate_alphanumeric()
+            scheme = FauxFactory.generate_alphanumeric()
             with self.assertRaises(ValueError):
-                self.factory.generate_url(scheme=scheme)
+                FauxFactory.generate_url(scheme=scheme)
 
     def test_generate_url_6(self):
         """
@@ -111,8 +103,8 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            subdomain = self.factory.generate_alphanumeric()
-            result = self.factory.generate_url(subdomain=subdomain)
+            subdomain = FauxFactory.generate_alphanumeric()
+            result = FauxFactory.generate_url(subdomain=subdomain)
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -131,7 +123,7 @@ class TestURLs(unittest.TestCase):
         @Assert: URL should be created with a random subdomain
         """
 
-        result = self.factory.generate_url(subdomain='')
+        result = FauxFactory.generate_url(subdomain='')
         self.assertTrue(
             len(result) > 0,
             "A valid URL was not generated.")
@@ -144,7 +136,7 @@ class TestURLs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            self.factory.generate_url(subdomain=" ")
+            FauxFactory.generate_url(subdomain=" ")
 
     def test_generate_url_9(self):
         """
@@ -154,9 +146,9 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            subdomain = self.factory.generate_cjk()
+            subdomain = FauxFactory.generate_cjk()
             with self.assertRaises(ValueError):
-                self.factory.generate_url(subdomain=subdomain)
+                FauxFactory.generate_url(subdomain=subdomain)
 
     def test_generate_url_10(self):
         """
@@ -166,8 +158,8 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            tlds = self.factory.generate_alpha(length=3)
-            result = self.factory.generate_url(tlds=tlds)
+            tlds = FauxFactory.generate_alpha(length=3)
+            result = FauxFactory.generate_url(tlds=tlds)
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -185,8 +177,8 @@ class TestURLs(unittest.TestCase):
 
         for turn in range(10):
             with self.assertRaises(ValueError):
-                tlds = self.factory.generate_numeric_string(length=3)
-                self.factory.generate_url(tlds=tlds)
+                tlds = FauxFactory.generate_numeric_string(length=3)
+                FauxFactory.generate_url(tlds=tlds)
 
     def test_generate_url_12(self):
         """
@@ -197,4 +189,4 @@ class TestURLs(unittest.TestCase):
 
         for turn in range(10):
             with self.assertRaises(ValueError):
-                self.factory.generate_url(tlds=" ")
+                FauxFactory.generate_url(tlds=" ")

--- a/tests/test_uuids.py
+++ b/tests/test_uuids.py
@@ -14,14 +14,6 @@ class TestUUID(unittest.TestCase):
     Test UUID generator
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Instantiate our factory object
-        """
-
-        cls.factory = FauxFactory()
-
     def test_generate_uuid_1(self):
         """
         @Test: Create a random UUID4 value
@@ -30,6 +22,6 @@ class TestUUID(unittest.TestCase):
         """
 
         for turn in range(100):
-            result = self.factory.generate_uuid()
+            result = FauxFactory.generate_uuid()
             self.assertGreater(len(result), 0,
                                "A valid UUID value was not generated.")


### PR DESCRIPTION
All methods on FauxFactory are class methods. Do not instantiate FauxFactory
when running unit tests.
