### PR TITLE
Make function names terse. Make functions private.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,7 +62,7 @@ Need a 10 character string for one of your tests?
 
 .. doctest::
 
-    >>> string = fauxfactory.generate_string('alphanumeric', 10)
+    >>> string = fauxfactory.gen_string('alphanumeric', 10)
     >>> string.isalnum()
     True
     >>> len(string)
@@ -72,7 +72,7 @@ Need a 5 character numeric string?
 
 .. doctest::
 
-    >>> string = fauxfactory.generate_string('numeric', 5)
+    >>> string = fauxfactory.gen_string('numeric', 5)
     >>> string.isnumeric()
     True
     >>> len(string)
@@ -83,16 +83,16 @@ Now, let's say you need a random date:
 .. doctest::
 
     >>> import datetime
-    >>> isinstance(fauxfactory.generate_date(), datetime.date)
+    >>> isinstance(fauxfactory.gen_date(), datetime.date)
     True
-    >>> isinstance(fauxfactory.generate_datetime(), datetime.datetime)
+    >>> isinstance(fauxfactory.gen_datetime(), datetime.datetime)
     True
 
 Or a fake email with your company domain:
 
 .. doctest::
 
-    >>> email = fauxfactory.generate_email(domain='mycompany')
+    >>> email = fauxfactory.gen_email(domain='mycompany')
     >>> '@mycompany' in email
     True
 

--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -1,31 +1,29 @@
 # -*- coding: utf-8 -*-
-
 """Generate random data for your tests."""
 
 __all__ = (
-    'codify',
-    'generate_alpha',
-    'generate_alphanumeric',
-    'generate_boolean',
-    'generate_choice',
-    'generate_cjk',
-    'generate_date',
-    'generate_datetime',
-    'generate_email',
-    'generate_html',
-    'generate_integer',
-    'generate_iplum',
-    'generate_latin1',
-    'generate_mac',
-    'generate_negative_integer',
-    'generate_numeric_string',
-    'generate_positive_integer',
-    'generate_string',
-    'generate_time',
-    'generate_url',
-    'generate_utf8',
-    'generate_uuid',
-    'generate_ipaddr',
+    'gen_alpha',
+    'gen_alphanumeric',
+    'gen_boolean',
+    'gen_choice',
+    'gen_cjk',
+    'gen_date',
+    'gen_datetime',
+    'gen_email',
+    'gen_html',
+    'gen_integer',
+    'gen_ipaddr',
+    'gen_iplum',
+    'gen_latin1',
+    'gen_mac',
+    'gen_negative_integer',
+    'gen_numeric_string',
+    'gen_positive_integer',
+    'gen_string',
+    'gen_time',
+    'gen_url',
+    'gen_utf8',
+    'gen_uuid',
 )
 
 import datetime
@@ -43,7 +41,10 @@ from fauxfactory.constants import (
 )
 
 
-def codify(data):
+# Private Functions -----------------------------------------------------------
+
+
+def _make_unicode(data):
     """Convert ``data`` to a unicode string if running Python 2.
 
     :param str data: A string to be type cast.
@@ -52,12 +53,12 @@ def codify(data):
 
     """
     if sys.version_info[0] is 2:
-        return unicode(data)
+        # (undefined-variable) pylint:disable=E0602
+        return unicode(data)  # flake8:noqa
     return data
-    pass
 
 
-def is_positive_int(length):
+def _is_positive_int(length):
     """Check that ``length`` argument is an integer greater than zero.
 
     :param int length: The desired length of the string
@@ -71,7 +72,10 @@ def is_positive_int(length):
         raise ValueError("{0} is an invalid 'length'.".format(length))
 
 
-def generate_string(str_type, length):
+# Public Functions ------------------------------------------------------------
+
+
+def gen_string(str_type, length):
     """A simple wrapper that calls other string generation methods.
 
     :param str str_type: The type of string which should be generated.
@@ -93,13 +97,13 @@ def generate_string(str_type, length):
 
     """
     str_types_functions = {
-        u'alpha': generate_alpha,
-        u'alphanumeric': generate_alphanumeric,
-        u'cjk': generate_cjk,
-        u'html': generate_html,
-        u'latin1': generate_latin1,
-        u'numeric': generate_numeric_string,
-        u'utf8': generate_utf8,
+        u'alpha': gen_alpha,
+        u'alphanumeric': gen_alphanumeric,
+        u'cjk': gen_cjk,
+        u'html': gen_html,
+        u'latin1': gen_latin1,
+        u'numeric': gen_numeric_string,
+        u'utf8': gen_utf8,
     }
     str_type_lower = str_type.lower()  # do not modify user data
     if str_type_lower not in str_types_functions.keys():
@@ -111,7 +115,7 @@ def generate_string(str_type, length):
     return method(length)
 
 
-def generate_alpha(length=5):
+def gen_alpha(length=5):
     """Returns a random string made up of alpha characters.
 
     @rtype length: int
@@ -123,16 +127,16 @@ def generate_alpha(length=5):
     """
 
     # Validate length argument
-    is_positive_int(length)
+    _is_positive_int(length)
 
     output_string = u''.join(
         random.choice(string.ascii_letters) for i in range(length)
     )
 
-    return codify(output_string)
+    return _make_unicode(output_string)
 
 
-def generate_alphanumeric(length=5):
+def gen_alphanumeric(length=5):
     """Returns a random string made up of alpha and numeric characters.
 
     @rtype length: int
@@ -144,17 +148,17 @@ def generate_alphanumeric(length=5):
     """
 
     # Validate length argument
-    is_positive_int(length)
+    _is_positive_int(length)
 
     output_string = u''.join(
         random.choice(
             string.ascii_letters + string.digits
         ) for i in range(length))
 
-    return codify(output_string)
+    return _make_unicode(output_string)
 
 
-def generate_boolean():
+def gen_boolean():
     """Returns a random Boolean value.
 
     @rtype: bool
@@ -164,10 +168,10 @@ def generate_boolean():
 
     choices = (True, False)
 
-    return generate_choice(choices)
+    return gen_choice(choices)
 
 
-def generate_choice(choices):
+def gen_choice(choices):
     """Returns a random choice from the available choices.
 
     @type choices: list
@@ -190,7 +194,7 @@ def generate_choice(choices):
     return random.choice(choices)
 
 
-def generate_cjk(length=5):
+def gen_cjk(length=5):
     """Returns a random string made up of CJK characters.
     (Source: Wikipedia - CJK Unified Ideographs)
 
@@ -203,20 +207,21 @@ def generate_cjk(length=5):
     """
 
     # Validate length argument
-    is_positive_int(length)
+    _is_positive_int(length)
 
     # Generate codepoints, then convert the codepoints to a string. The
     # valid range of CJK codepoints is 0x4E00 - 0x9FCC, inclusive. Python 2
     # and 3 support the `unichr` and `chr` functions, respectively.
-    codepoints = [random.randint(0x4E00, 0x9FCC) for i in range(length)]
+    codepoints = [random.randint(0x4E00, 0x9FCC) for _ in range(length)]
     try:
+        # (undefined-variable) pylint:disable=E0602
         output = u''.join(unichr(codepoint) for codepoint in codepoints)
     except NameError:
         output = u''.join(chr(codepoint) for codepoint in codepoints)
-    return codify(output)
+    return _make_unicode(output)
 
 
-def generate_date(min_date=None, max_date=None):
+def gen_date(min_date=None, max_date=None):
     """Returns a random date value
 
     @type min_date: object
@@ -256,7 +261,7 @@ def generate_date(min_date=None, max_date=None):
     return date
 
 
-def generate_datetime(min_date=None, max_date=None):
+def gen_datetime(min_date=None, max_date=None):
     """Returns a random datetime value
 
     @type min_date: object
@@ -295,7 +300,7 @@ def generate_datetime(min_date=None, max_date=None):
     return min_date + datetime.timedelta(seconds=seconds)
 
 
-def generate_email(name=None, domain=None, tlds=None):
+def gen_email(name=None, domain=None, tlds=None):
     """Generates a random email address.
 
     @type name: str
@@ -312,20 +317,20 @@ def generate_email(name=None, domain=None, tlds=None):
 
     # Generate a new name if needed
     if name is None:
-        name = generate_alpha(8)
+        name = gen_alpha(8)
     # Obtain a random domain if needed
     if domain is None:
-        domain = generate_choice(SUBDOMAINS)
+        domain = gen_choice(SUBDOMAINS)
     # Obtain a random top level domain if needed
     if tlds is None:
-        tlds = generate_choice(TLDS)
+        tlds = gen_choice(TLDS)
 
     email = u"{0}@{1}.{2}".format(name, domain, tlds)
 
-    return codify(email)
+    return _make_unicode(email)
 
 
-def generate_integer(min_value=None, max_value=None):
+def gen_integer(min_value=None, max_value=None):
     """Returns a random integer value based on the current platform.
 
     @type min_value: int
@@ -358,7 +363,7 @@ def generate_integer(min_value=None, max_value=None):
     return value
 
 
-def generate_iplum(words=None, paragraphs=None):
+def gen_iplum(words=None, paragraphs=None):
     """Returns a lorem ipsum string. If no arguments are passed, then
     return the entire default lorem ipsum string.
 
@@ -381,7 +386,7 @@ def generate_iplum(words=None, paragraphs=None):
     if not isinstance(words, int) or words < 0:
         raise ValueError(
             "Cannot generate a string with negative number of words.")
-    is_positive_int(paragraphs)
+    _is_positive_int(paragraphs)
 
     # Original Lorem Ipsum string
     all_words = LOREM_IPSUM_TEXT.split()
@@ -396,7 +401,7 @@ def generate_iplum(words=None, paragraphs=None):
 
     result = u""
     start_pos = 0
-    for idx in range(0, paragraphs):
+    for _ in range(0, paragraphs):
         sentence = u" ".join(
             all_words[start_pos:start_pos + words])
 
@@ -416,10 +421,10 @@ def generate_iplum(words=None, paragraphs=None):
 
         # Increment positional counter
         start_pos += words
-    return codify(result.rstrip())
+    return _make_unicode(result.rstrip())
 
 
-def generate_latin1(length=5):
+def gen_latin1(length=5):
     """Returns a random string made up of UTF-8 characters.
     (Font: Wikipedia - Latin-1 Supplement Unicode Block)
 
@@ -432,7 +437,7 @@ def generate_latin1(length=5):
     """
 
     # Validate length argument
-    is_positive_int(length)
+    _is_positive_int(length)
 
     range0 = range1 = range2 = []
     range0 = ['00C0', '00D6']
@@ -449,15 +454,16 @@ def generate_latin1(length=5):
 
     try:
         output_string = u''.join(
+            # (undefined-variable) pylint:disable=E0602
             unichr(random.choice(output_array)) for x in range(length))
     except NameError:
         output_string = u''.join(
             chr(random.choice(output_array)) for x in range(length))
 
-    return codify(output_string)
+    return _make_unicode(output_string)
 
 
-def generate_negative_integer():
+def gen_negative_integer():
     """Returns a random negative integer based on the current platform.
 
     @rtype: int
@@ -467,10 +473,10 @@ def generate_negative_integer():
 
     max_value = 0
 
-    return generate_integer(max_value=max_value)
+    return gen_integer(max_value=max_value)
 
 
-def generate_ipaddr(ip3=False, ipv6=False):
+def gen_ipaddr(ip3=False, ipv6=False):
     """Generates a random IP address.
 
     @type ip3: bool
@@ -496,10 +502,10 @@ def generate_ipaddr(ip3=False, ipv6=False):
         if ip3:
             ipaddr = ipaddr + u".0"
 
-    return codify(ipaddr)
+    return _make_unicode(ipaddr)
 
 
-def generate_mac(delimiter=":"):
+def gen_mac(delimiter=":"):
     """Generates a random MAC address.
 
     @type delimeter: str
@@ -520,10 +526,10 @@ def generate_mac(delimiter=":"):
         chars[random.randrange(0, len(chars), 1)]+chars[random.randrange(
             0, len(chars), 1)] for x in range(6))
 
-    return codify(mac)
+    return _make_unicode(mac)
 
 
-def generate_numeric_string(length=5):
+def gen_numeric_string(length=5):
     """Returns a random string made up of numbers.
 
     @type length: int
@@ -535,16 +541,16 @@ def generate_numeric_string(length=5):
     """
 
     # Validate length argument
-    is_positive_int(length)
+    _is_positive_int(length)
 
     output_string = u''.join(
         random.choice(string.digits) for i in range(length)
     )
 
-    return codify(output_string)
+    return _make_unicode(output_string)
 
 
-def generate_positive_integer():
+def gen_positive_integer():
     """Returns a random positive integer based on the current platform.
 
     @rtype: int
@@ -554,10 +560,10 @@ def generate_positive_integer():
 
     min_value = 0
 
-    return generate_integer(min_value=min_value)
+    return gen_integer(min_value=min_value)
 
 
-def generate_time():
+def gen_time():
     """Generates a random time.
 
     @rtype: object
@@ -573,7 +579,7 @@ def generate_time():
     )
 
 
-def generate_url(scheme=None, subdomain=None, tlds=None):
+def gen_url(scheme=None, subdomain=None, tlds=None):
     """Generates a random URL address
 
     @type scheme: str
@@ -599,26 +605,26 @@ def generate_url(scheme=None, subdomain=None, tlds=None):
         if schemenator.match(scheme) is None:
             raise ValueError("Protocol {0} is not valid.".format(scheme))
     else:
-        scheme = generate_choice(SCHEMES)
+        scheme = gen_choice(SCHEMES)
 
     if subdomain:
         if subdomainator.match(subdomain) is None:
             raise ValueError("Subdomain {0} is invalid.".format(subdomain))
     else:
-        subdomain = generate_choice(SUBDOMAINS)
+        subdomain = gen_choice(SUBDOMAINS)
 
     if tlds:
         if tldsnator.match(tlds) is None:
             raise ValueError("TLDS name {0} is invalid.".format(tlds))
     else:
-        tlds = generate_choice(TLDS)
+        tlds = gen_choice(TLDS)
 
     url = u"{0}://{1}.{2}".format(scheme, subdomain, tlds)
 
-    return codify(url)
+    return _make_unicode(url)
 
 
-def generate_utf8(length=5):
+def gen_utf8(length=5):
     """Returns a random string made up of UTF-8 characters, as per RFC 3629.
 
     @rtype length: int
@@ -630,7 +636,7 @@ def generate_utf8(length=5):
     """
 
     # Validate length argument
-    is_positive_int(length)
+    _is_positive_int(length)
 
     # Generate codepoints. The valid range of UTF-8 codepoints is
     # 0x0-0x10FFFF, minus the following: 0xC0-0xC1, 0xF5-0xFF and
@@ -654,13 +660,14 @@ def generate_utf8(length=5):
     # Convert codepoints to characters. Python 2 and 3 support the `unichr`
     # and `chr` functions, respectively.
     try:
+        # (undefined-variable) pylint:disable=E0602
         output = u''.join(unichr(codepoint) for codepoint in codepoints)
     except NameError:
         output = u''.join(chr(codepoint) for codepoint in codepoints)
-    return codify(output)
+    return _make_unicode(output)
 
 
-def generate_uuid():
+def gen_uuid():
     """Generates a UUID string (universally unique identifiers).
 
     @rtype: str
@@ -668,12 +675,12 @@ def generate_uuid():
 
     """
 
-    output_uuid = codify(str(uuid.uuid4()))
+    output_uuid = _make_unicode(str(uuid.uuid4()))
 
     return output_uuid
 
 
-def generate_html(length=5):
+def gen_html(length=5):
     """Returns a random string made up of html characters.
 
     @rtype length: int
@@ -684,10 +691,10 @@ def generate_html(length=5):
     """
 
     # Validate length argument
-    is_positive_int(length)
+    _is_positive_int(length)
 
     html_tag = random.choice(HTML_TAGS)
     output_string = u'<{0}>{1}</{2}>'.format(
-        html_tag, generate_string("alpha", length), html_tag)
+        html_tag, gen_string("alpha", length), html_tag)
 
-    return codify(output_string)
+    return _make_unicode(output_string)

--- a/tests/test_booleans.py
+++ b/tests/test_booleans.py
@@ -2,7 +2,7 @@
 
 """Tests for all boolean generators."""
 
-from fauxfactory import generate_boolean
+from fauxfactory import gen_boolean
 
 import unittest
 
@@ -10,7 +10,7 @@ import unittest
 class TestBooleans(unittest.TestCase):
     """Test boolean generator."""
 
-    def test_generate_boolean_1(self):
+    def test_gen_boolean_1(self):
         """
         @Test: Create a random boolean value
         @Feature: Boolean Generator
@@ -18,7 +18,7 @@ class TestBooleans(unittest.TestCase):
         """
 
         for turn in range(100):
-            result = generate_boolean()
+            result = gen_boolean()
             self.assertIsInstance(
                 result, bool,
                 "A valid boolean value was not generated.")

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -2,7 +2,7 @@
 
 """Tests for all choice generators."""
 
-from fauxfactory import generate_choice
+from fauxfactory import gen_choice
 
 import string
 import unittest
@@ -11,7 +11,7 @@ import unittest
 class TestChoices(unittest.TestCase):
     """Test choices generator."""
 
-    def test_generate_choice_1(self):
+    def test_gen_choice_1(self):
         """
         @Test: Select a random value from integer values
         @Feature: Choice Generator
@@ -21,13 +21,13 @@ class TestChoices(unittest.TestCase):
         choices = range(5)
 
         for turn in range(10):
-            result = generate_choice(choices)
+            result = gen_choice(choices)
             self.assertIn(
                 result,
                 choices,
                 "An invalid value was selected from available choices.")
 
-    def test_generate_choice_2(self):
+    def test_gen_choice_2(self):
         """
         @Test: Select a random value from alphanumeric values
         @Feature: Choice Generator
@@ -37,13 +37,13 @@ class TestChoices(unittest.TestCase):
         choices = string.ascii_letters + string.digits
 
         for turn in range(10):
-            result = generate_choice(choices)
+            result = gen_choice(choices)
             self.assertIn(
                 result,
                 choices,
                 "An invalid value was selected from available choices.")
 
-    def test_generate_choice_3(self):
+    def test_gen_choice_3(self):
         """
         @Test: Select a random value from short list
         @Feature: Choice Generator
@@ -53,13 +53,13 @@ class TestChoices(unittest.TestCase):
         choices = [1, ]
 
         for turn in range(10):
-            result = generate_choice(choices)
+            result = gen_choice(choices)
             self.assertEqual(
                 result,
                 choices[0],
                 "An invalid value was selected from available choices.")
 
-    def test_generate_choice_4(self):
+    def test_gen_choice_4(self):
         """
         @Test: Select a random value from longer list
         @Feature: Choice Generator
@@ -69,13 +69,13 @@ class TestChoices(unittest.TestCase):
         choices = [1, 2, 3, 9, 10, 11, 100, 101, 102]
 
         for turn in range(10):
-            result = generate_choice(choices)
+            result = gen_choice(choices)
             self.assertIn(
                 result,
                 choices,
                 "An invalid value was selected from available choices.")
 
-    def test_generate_choice_5(self):
+    def test_gen_choice_5(self):
         """
         @Test: Select a random value from short tuple
         @Feature: Choice Generator
@@ -85,13 +85,13 @@ class TestChoices(unittest.TestCase):
         choices = (1, )
 
         for turn in range(10):
-            result = generate_choice(choices)
+            result = gen_choice(choices)
             self.assertEqual(
                 result,
                 choices[0],
                 "An invalid value was selected from available choices.")
 
-    def test_generate_choice_6(self):
+    def test_gen_choice_6(self):
         """
         @Test: Select a random value from longer tuple
         @Feature: Choice Generator
@@ -101,13 +101,13 @@ class TestChoices(unittest.TestCase):
         choices = (1, 2, 3, 9, 10, 11, 100, 101, 102, )
 
         for turn in range(10):
-            result = generate_choice(choices)
+            result = gen_choice(choices)
             self.assertIn(
                 result,
                 choices,
                 "An invalid value was selected from available choices.")
 
-    def test_generate_choice_7(self):
+    def test_gen_choice_7(self):
         """
         @Test: Select a random value from empty list
         @Feature: Choice Generator
@@ -117,9 +117,9 @@ class TestChoices(unittest.TestCase):
         choices = []
 
         with self.assertRaises(ValueError):
-            generate_choice(choices)
+            gen_choice(choices)
 
-    def test_generate_choice_8(self):
+    def test_gen_choice_8(self):
         """
         @Test: Select a random value from empty tuple
         @Feature: Choice Generator
@@ -129,9 +129,9 @@ class TestChoices(unittest.TestCase):
         choices = ()
 
         with self.assertRaises(ValueError):
-            generate_choice(choices)
+            gen_choice(choices)
 
-    def test_generate_choice_9(self):
+    def test_gen_choice_9(self):
         """
         @Test: Select a random value from empty dictionary
         @Feature: Choice Generator
@@ -141,9 +141,9 @@ class TestChoices(unittest.TestCase):
         choices = {}
 
         with self.assertRaises(ValueError):
-            generate_choice(choices)
+            gen_choice(choices)
 
-    def test_generate_choice_10(self):
+    def test_gen_choice_10(self):
         """
         @Test: Select a random value from single dictionary
         @Feature: Choice Generator
@@ -153,9 +153,9 @@ class TestChoices(unittest.TestCase):
         choices = {'Name': 'Bob', 'Age': 39}
 
         with self.assertRaises(ValueError):
-            generate_choice(choices)
+            gen_choice(choices)
 
-    def test_generate_choice_11(self):
+    def test_gen_choice_11(self):
         """
         @Test: Select a random value from dictionary list
         @Feature: Choice Generator
@@ -169,13 +169,13 @@ class TestChoices(unittest.TestCase):
         ]
 
         for turn in range(10):
-            result = generate_choice(choices)
+            result = gen_choice(choices)
             self.assertIn(
                 result,
                 choices,
                 "An invalid value was selected from available choices.")
 
-    def test_generate_choice_12(self):
+    def test_gen_choice_12(self):
         """
         @Test: Select a random value from words list
         @Feature: Choice Generator
@@ -185,13 +185,13 @@ class TestChoices(unittest.TestCase):
         choices = ['green', 'yellow', 'blue' 'white']
 
         for turn in range(10):
-            result = generate_choice(choices)
+            result = gen_choice(choices)
             self.assertIn(
                 result,
                 choices,
                 "An invalid value was selected from available choices.")
 
-    def test_generate_choice_13(self):
+    def test_gen_choice_13(self):
         """
         @Test: Cannot use None for Choice generator
         @Feature: Choice Generator
@@ -201,4 +201,4 @@ class TestChoices(unittest.TestCase):
         choices = None
 
         with self.assertRaises(ValueError):
-            generate_choice(choices)
+            gen_choice(choices)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -2,7 +2,7 @@
 
 """Tests for date generator."""
 
-from fauxfactory import generate_date
+from fauxfactory import gen_date
 from fauxfactory.constants import MAX_YEARS, MIN_YEARS
 
 import datetime
@@ -12,18 +12,18 @@ import unittest
 class TestDates(unittest.TestCase):
     """Test date generator."""
 
-    def test_generate_date_1(self):
+    def test_gen_date_1(self):
         """
         @Test: Create a date with no arguments
         @Feature: Date Generator
         @Assert: Date is created with random values.
         """
-        result = generate_date()
+        result = gen_date()
         self.assertTrue(
             isinstance(result, datetime.date),
             "Data is not instance of datetime.date.")
 
-    def test_generate_date_2(self):
+    def test_gen_date_2(self):
         """
         @Test: Create a date with only min_date
         @Feature: Date Generator
@@ -36,10 +36,10 @@ class TestDates(unittest.TestCase):
         min_date = today - datetime.timedelta(5)
 
         for turn in range(10):
-            result = generate_date(min_date=min_date)
+            result = gen_date(min_date=min_date)
             self.assertTrue(result >= min_date)
 
-    def test_generate_date_3(self):
+    def test_gen_date_3(self):
         """
         @Test: Create a date with only max_date
         @Feature: Date Generator
@@ -52,10 +52,10 @@ class TestDates(unittest.TestCase):
         max_date = today + datetime.timedelta(5)
 
         for turn in range(10):
-            result = generate_date(max_date=max_date)
+            result = gen_date(max_date=max_date)
             self.assertTrue(result <= max_date)
 
-    def test_generate_date_4(self):
+    def test_gen_date_4(self):
         """
         @Test: Create a date with both arguments
         @Feature: Date Generator
@@ -70,14 +70,14 @@ class TestDates(unittest.TestCase):
         max_date = today + datetime.timedelta(5)
 
         for turn in range(10):
-            result = generate_date(
+            result = gen_date(
                 min_date=min_date,
                 max_date=max_date
             )
             self.assertTrue(result >= min_date)
             self.assertTrue(result <= max_date)
 
-    def test_generate_date_5(self):
+    def test_gen_date_5(self):
         """
         @Test: Create a date with min_date == 'None'
         @Feature: Date Generator
@@ -91,14 +91,14 @@ class TestDates(unittest.TestCase):
         max_date = min_date + datetime.timedelta(365 * 1)
 
         for turn in range(20):
-            result = generate_date(
+            result = gen_date(
                 min_date=None,
                 max_date=max_date
             )
             self.assertTrue(result.year <= max_date.year)
             self.assertTrue(result.year >= min_date.year)
 
-    def test_generate_date_6(self):
+    def test_gen_date_6(self):
         """
         @Test: Create a date with max_date == 'None'
         @Feature: Date Generator
@@ -112,14 +112,14 @@ class TestDates(unittest.TestCase):
         min_date = max_date - datetime.timedelta(365 * 1)
 
         for turn in range(20):
-            result = generate_date(
+            result = gen_date(
                 min_date=min_date,
                 max_date=None
             )
             self.assertTrue(result.year <= max_date.year, result)
             self.assertTrue(result.year >= min_date.year, result)
 
-    def test_generate_date_7(self):
+    def test_gen_date_7(self):
         """
         @Test: Create a date with specific date ranges
         @Feature: Date Generator
@@ -134,14 +134,14 @@ class TestDates(unittest.TestCase):
                     datetime.timedelta(365 * MAX_YEARS))
 
         for turn in range(20):
-            result = generate_date(
+            result = gen_date(
                 min_date=min_date,
                 max_date=max_date
             )
             self.assertTrue(result.year <= max_date.year, result)
             self.assertTrue(result.year >= min_date.year, result)
 
-    def test_generate_date_8(self):
+    def test_gen_date_8(self):
         """
         @Test: Create a date with non-Date arguments
         @Feature: Date Generator
@@ -149,12 +149,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_date(
+            gen_date(
                 min_date='',
                 max_date=''
             )
 
-    def test_generate_date_9(self):
+    def test_gen_date_9(self):
         """
         @Test: Create a date with non-Date arguments
         @Feature: Date Generator
@@ -162,12 +162,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_date(
+            gen_date(
                 min_date='abc',
                 max_date='def'
             )
 
-    def test_generate_date_10(self):
+    def test_gen_date_10(self):
         """
         @Test: Create a date with non-Date arguments
         @Feature: Date Generator
@@ -175,12 +175,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_date(
+            gen_date(
                 min_date=1,
                 max_date=1
             )
 
-    def test_generate_date_11(self):
+    def test_gen_date_11(self):
         """
         @Test: Create a date with non-Date arguments
         @Feature: Date Generator
@@ -188,12 +188,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_date(
+            gen_date(
                 min_date=(1,),
                 max_date=(2, 3, 4)
             )
 
-    def test_generate_date_12(self):
+    def test_gen_date_12(self):
         """
         @Test: Create a date with non-Date arguments
         @Feature: Date Generator
@@ -201,12 +201,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_date(
+            gen_date(
                 min_date=['a', 'b'],
                 max_date=['c', 'd', 'e']
             )
 
-    def test_generate_date_13(self):
+    def test_gen_date_13(self):
         """
         @Test: Create a date with min_date > max_date
         @Feature: Date Generator
@@ -219,12 +219,12 @@ class TestDates(unittest.TestCase):
         min_date = today + datetime.timedelta(5)
 
         with self.assertRaises(AssertionError):
-            generate_date(
+            gen_date(
                 min_date=min_date,
                 max_date=today
             )
 
-    def test_generate_date_14(self):
+    def test_gen_date_14(self):
         """
         @Test: max-date must be a Date type
         @Feature: Date Generator
@@ -232,7 +232,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_date(
+            gen_date(
                 min_date=datetime.date.today(),
                 max_date='foo'
             )

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -2,7 +2,7 @@
 
 """Tests for datetime generator."""
 
-from fauxfactory import generate_date, generate_datetime
+from fauxfactory import gen_date, gen_datetime
 from fauxfactory.constants import MAX_YEARS, MIN_YEARS
 
 import datetime
@@ -14,19 +14,19 @@ class TestDates(unittest.TestCase):
     Test datetime generator
     """
 
-    def test_generate_datetime_1(self):
+    def test_gen_datetime_1(self):
         """
         @Test: Create a datetime with no arguments
         @Feature: DateTime Generator
         @Assert: Datetime is created with random values
         """
 
-        result = generate_datetime()
+        result = gen_datetime()
         self.assertTrue(
             isinstance(result, datetime.datetime),
             "Data is not instance of datetime.date.")
 
-    def test_generate_datetime_2(self):
+    def test_gen_datetime_2(self):
         """
         @Test: Create a datetime with only min_date
         @Feature: DateTime Generator
@@ -39,10 +39,10 @@ class TestDates(unittest.TestCase):
         min_date = today - datetime.timedelta(seconds=5*60)
 
         for turn in range(10):
-            result = generate_datetime(min_date=min_date)
+            result = gen_datetime(min_date=min_date)
             self.assertTrue(result >= min_date)
 
-    def test_generate_datetime_3(self):
+    def test_gen_datetime_3(self):
         """
         @Test: Create a datetime with only max_date
         @Feature: DateTime Generator
@@ -55,10 +55,10 @@ class TestDates(unittest.TestCase):
         max_date = today + datetime.timedelta(seconds=5*60)
 
         for turn in range(10):
-            result = generate_datetime(max_date=max_date)
+            result = gen_datetime(max_date=max_date)
             self.assertTrue(result <= max_date)
 
-    def test_generate_datetime_4(self):
+    def test_gen_datetime_4(self):
         """
         @Test: Create a datetime with a 5-days datetime range
         @Feature: DateTime Generator
@@ -73,14 +73,14 @@ class TestDates(unittest.TestCase):
         max_date = today + datetime.timedelta(seconds=5*60)
 
         for turn in range(10):
-            result = generate_datetime(
+            result = gen_datetime(
                 min_date=min_date,
                 max_date=max_date
             )
             self.assertTrue(result >= min_date)
             self.assertTrue(result <= max_date)
 
-    def test_generate_datetime_5(self):
+    def test_gen_datetime_5(self):
         """
         @Test: Create a datetime with min_date = None
         @Feature: DateTime Generator
@@ -94,14 +94,14 @@ class TestDates(unittest.TestCase):
         max_date = min_date + datetime.timedelta(365 * 1)
 
         for turn in range(20):
-            result = generate_datetime(
+            result = gen_datetime(
                 min_date=None,
                 max_date=max_date
             )
             self.assertTrue(result.year <= max_date.year)
             self.assertTrue(result.year >= min_date.year)
 
-    def test_generate_datetime_6(self):
+    def test_gen_datetime_6(self):
         """
         @Test: Create a datetime with max_date == None
         @Feature: DateTime Generator
@@ -115,14 +115,14 @@ class TestDates(unittest.TestCase):
         min_date = max_date - datetime.timedelta(365 * 1)
 
         for turn in range(20):
-            result = generate_datetime(
+            result = gen_datetime(
                 min_date=min_date,
                 max_date=None
             )
             self.assertTrue(result.year <= max_date.year, result)
             self.assertTrue(result.year >= min_date.year, result)
 
-    def test_generate_datetime_7(self):
+    def test_gen_datetime_7(self):
         """
         @Test: Create a datetime with specified datetime ranges
         @Feature: DateTime Generator
@@ -137,14 +137,14 @@ class TestDates(unittest.TestCase):
                     datetime.timedelta(365 * MAX_YEARS))
 
         for turn in range(20):
-            result = generate_datetime(
+            result = gen_datetime(
                 min_date=min_date,
                 max_date=max_date
             )
             self.assertTrue(result.year <= max_date.year, result)
             self.assertTrue(result.year >= min_date.year, result)
 
-    def test_generate_datetime_8(self):
+    def test_gen_datetime_8(self):
         """
         @Test: Create a datetime with non-Date arguments
         @Feature: DateTime Generator
@@ -152,12 +152,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_datetime(
+            gen_datetime(
                 min_date='',
                 max_date=''
             )
 
-    def test_generate_datetime_9(self):
+    def test_gen_datetime_9(self):
         """
         @Test: Create a datetime with non-Date arguments
         @Feature: DateTime Generator
@@ -165,12 +165,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_datetime(
+            gen_datetime(
                 min_date='abc',
                 max_date='def'
             )
 
-    def test_generate_datetime_10(self):
+    def test_gen_datetime_10(self):
         """
         @Test: Create a datetime with non-Date arguments
         @Feature: DateTime Generator
@@ -178,12 +178,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_datetime(
+            gen_datetime(
                 min_date=1,
                 max_date=1
             )
 
-    def test_generate_datetime_11(self):
+    def test_gen_datetime_11(self):
         """
         @Test: Create a datetime with non-Date arguments
         @Feature: DateTime Generator
@@ -191,12 +191,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_datetime(
+            gen_datetime(
                 min_date=(1,),
                 max_date=(2, 3, 4)
             )
 
-    def test_generate_datetime_12(self):
+    def test_gen_datetime_12(self):
         """
         @Test: Create a datetime with non-Date arguments
         @Feature: DateTime Generator
@@ -204,12 +204,12 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_datetime(
+            gen_datetime(
                 min_date=['a', 'b'],
                 max_date=['c', 'd', 'e']
             )
 
-    def test_generate_datetime_13(self):
+    def test_gen_datetime_13(self):
         """
         @Test: Create a datetime with min_date > max_date
         @Feature: DateTime Generator
@@ -222,12 +222,12 @@ class TestDates(unittest.TestCase):
         min_date = today + datetime.timedelta(seconds=5*60)
 
         with self.assertRaises(AssertionError):
-            generate_datetime(
+            gen_datetime(
                 min_date=min_date,
                 max_date=today
             )
 
-    def test_generate_date_14(self):
+    def test_gen_date_14(self):
         """
         @Test: max-date must be a Datetime type
         @Feature: DateTime Generator
@@ -235,7 +235,7 @@ class TestDates(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_date(
+            gen_date(
                 min_date=datetime.datetime.now(),
                 max_date='foo'
             )

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -2,7 +2,7 @@
 
 """Tests for Email generator."""
 
-from fauxfactory import generate_email
+from fauxfactory import gen_email
 
 import re
 import unittest
@@ -13,7 +13,7 @@ REGEX = r"^[a-zA-Z][a-zA-Z-.]*[^.-]@\w*\.[a-zA-Z]{2,3}"
 class TestEmails(unittest.TestCase):
     """Test Email generator."""
 
-    def test_generate_email_1(self):
+    def test_gen_email_1(self):
         """
         @Test: Create a random email value
         @Feature: Email Generator
@@ -23,7 +23,7 @@ class TestEmails(unittest.TestCase):
         # Regex for email validation
         emailinator = re.compile(REGEX)
         for turn in range(100):
-            result = generate_email()
+            result = gen_email()
 
             self.assertIsNotNone(
                 emailinator.match(result),

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -2,7 +2,7 @@
 
 """Tests for HTML generator."""
 
-from fauxfactory import generate_html, generate_integer
+from fauxfactory import gen_html, gen_integer
 import re
 import sys
 import unittest
@@ -29,7 +29,7 @@ class TestHTML(unittest.TestCase):
         @Assert: The contents of the HTML tag are at least one character long.
         """
 
-        match = self.matcher.search(generate_html())
+        match = self.matcher.search(gen_html())
         self.assertGreaterEqual(len(match.group(1)), 1)
 
     def test_length_arg_provided(self):
@@ -40,8 +40,8 @@ class TestHTML(unittest.TestCase):
         @Assert: The contents of the HTML tag are ``length`` characters long.
         """
 
-        length = generate_integer(1, 25)
-        match = self.matcher.search(generate_html(length))
+        length = gen_integer(1, 25)
+        match = self.matcher.search(gen_html(length))
         self.assertEqual(len(match.group(1)), length)
 
     def test_unicode(self):
@@ -51,7 +51,7 @@ class TestHTML(unittest.TestCase):
         @Assert: A unicode string is generated.
         """
 
-        result = generate_html()
+        result = gen_html()
         if sys.version_info[0] is 2:
             # (undefined-variable) pylint:disable=E0602
             self.assertIsInstance(result, unicode)  # flake8:noqa

--- a/tests/test_ipaddress.py
+++ b/tests/test_ipaddress.py
@@ -2,7 +2,7 @@
 
 """Tests for ipaddr generator."""
 
-from fauxfactory import generate_ipaddr
+from fauxfactory import gen_ipaddr
 
 import unittest
 
@@ -10,7 +10,7 @@ import unittest
 class TestIpaddr(unittest.TestCase):
     """Test ipaddr generator."""
 
-    def test_generate_ipv4_1(self):
+    def test_gen_ipv4_1(self):
         """
         @Test: Generate a 3 group IPv4 address
         @Feature: IPAddr Generator
@@ -18,67 +18,67 @@ class TestIpaddr(unittest.TestCase):
                  will always end with a \'.0\')
         """
 
-        result = generate_ipaddr(ip3=True)
+        result = gen_ipaddr(ip3=True)
         self.assertTrue(
             result.split(".")[-1] == '0',
             "Did not generate a 3-group IPv4 addrss")
 
-    def test_generate_ipv4_2(self):
+    def test_gen_ipv4_2(self):
         """
         @Test: Generate a 4 group IPv4 address
         @Feature: IPAddr Generator
         @Assert: A 4-group IPv4 address is generated
         """
 
-        result = generate_ipaddr()
+        result = gen_ipaddr()
         self.assertTrue(
             len(result.split(".")) == 4,
             "Did not generate a 4-group IPv4 addrss")
 
-    def test_generate_ipv4_3(self):
+    def test_gen_ipv4_3(self):
         """
         @Test: Generate a 4 group IPv4 address
         @Feature: IPAddr Generator
         @Assert: A 4-group IPv4 address is generated
         """
 
-        result = generate_ipaddr(ip3=False)
+        result = gen_ipaddr(ip3=False)
         self.assertTrue(
             len(result.split(".")) == 4,
             "Did not generate a 4-group IPv4 addrss")
 
-    def test_generate_ipv4_4(self):
+    def test_gen_ipv4_4(self):
         """
         @Test: Generate a 4 group IPv4 address
         @Feature: IPAddr Generator
         @Assert: A 4-group IPv4 address is generated
         """
 
-        result = generate_ipaddr(ip3=False, ipv6=False)
+        result = gen_ipaddr(ip3=False, ipv6=False)
         self.assertTrue(
             len(result.split(".")) == 4,
             "Did not generate a 4-group IPv4 addrss")
 
-    def test_generate_ipv6_1(self):
+    def test_gen_ipv6_1(self):
         """
         @Test: Generate a IPv6 address
         @Feature: IPAddr Generator
         @Assert: A IPv6 address is generated
         """
 
-        result = generate_ipaddr(ipv6=True)
+        result = gen_ipaddr(ipv6=True)
         self.assertTrue(
             len(result.split(":")) == 8,
             "Did not generate a IPv6 addrss")
 
-    def test_generate_ipv6_2(self):
+    def test_gen_ipv6_2(self):
         """
         @Test: Generate a IPv6 address
         @Feature: IPAddr Generator
         @Assert: A IPv6 address is generated
         """
 
-        result = generate_ipaddr(ip3=True, ipv6=True)
+        result = gen_ipaddr(ip3=True, ipv6=True)
         self.assertTrue(
             len(result.split(":")) == 8,
             "Did not generate a IPv6 addrss")

--- a/tests/test_lorem_ipsum.py
+++ b/tests/test_lorem_ipsum.py
@@ -2,7 +2,7 @@
 
 """Tests for Lorem Ipsum generator."""
 
-from fauxfactory import generate_iplum
+from fauxfactory import gen_iplum
 from fauxfactory.constants import LOREM_IPSUM_TEXT
 
 import random
@@ -14,14 +14,14 @@ class TestLoremIpsum(unittest.TestCase):
     Test lorem ipsum generator
     """
 
-    def test_generate_loremipsum_1(self):
+    def test_gen_loremipsum_1(self):
         """
         @Test: Create a complete lorem ipsum string
         @Feature: Lorem Ipsum Generator
         @Assert: Complete lorem ipsum value that starts with 'Lorem ipsum'
         """
 
-        result = generate_iplum()
+        result = gen_iplum()
         self.assertEqual(
             result,
             LOREM_IPSUM_TEXT, "Generated text is not Lorem Ipsum")
@@ -30,7 +30,7 @@ class TestLoremIpsum(unittest.TestCase):
             "Generated string does not start with Lorem Ipsum"
         )
 
-    def test_generate_loremipsum_2(self):
+    def test_gen_loremipsum_2(self):
         """
         @Test: Create a lorem ipsum string with fixed number of words
         @Feature: Lorem Ipsum Generator
@@ -39,13 +39,13 @@ class TestLoremIpsum(unittest.TestCase):
 
         for i in range(20):
             length = random.randint(1, 500)
-            result = generate_iplum(words=length)
+            result = gen_iplum(words=length)
             self.assertEqual(
                 len(result.split()),
                 length,
                 "Generated string does not have the correct number of words")
 
-    def test_generate_loremipsum_3(self):
+    def test_gen_loremipsum_3(self):
         """
         @Test: Create a lorem ipsum string with fixed number of paragraphs
         @Feature: Lorem Ipsum Generator
@@ -54,26 +54,26 @@ class TestLoremIpsum(unittest.TestCase):
 
         for i in range(20):
             length = random.randint(1, 20)
-            result = generate_iplum(paragraphs=length)
+            result = gen_iplum(paragraphs=length)
             self.assertEqual(
                 len(result.split('\n')),
                 length,
                 "Generated string does not have the correct number"
                 " of paragraphs")
 
-    def test_generate_loremipsum_4(self):
+    def test_gen_loremipsum_4(self):
         """
         @Test: Create a lorem ipsum string with zero words
         @Feature: Lorem Ipsum Generator
         @Assert: Complete lorem ipsum value is returned
         """
 
-        result = generate_iplum(words=0)
+        result = gen_iplum(words=0)
         self.assertEqual(
             result,
             LOREM_IPSUM_TEXT, "Generated text is not Lorem Ipsum")
 
-    def test_generate_loremipsum_5(self):
+    def test_gen_loremipsum_5(self):
         """
         @Test: Create a lorem ipsum string with zero paragraphs
         @Feature: Lorem Ipsum Generator
@@ -81,9 +81,9 @@ class TestLoremIpsum(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_iplum(paragraphs=0)
+            gen_iplum(paragraphs=0)
 
-    def test_generate_loremipsum_6(self):
+    def test_gen_loremipsum_6(self):
         """
         @Test: Create a lorem ipsum string with 1 word and 0 paragragh
         @Feature: Lorem Ipsum Generator
@@ -91,21 +91,21 @@ class TestLoremIpsum(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_iplum(words=1, paragraphs=0)
+            gen_iplum(words=1, paragraphs=0)
 
-    def test_generate_loremipsum_7(self):
+    def test_gen_loremipsum_7(self):
         """
         @Test: Create a lorem ipsum string with 1 word and 1 paragragh
         @Feature: Lorem Ipsum Generator
         @Assert: Generated string has 1 word in 1 paragraph
         """
 
-        result = generate_iplum(words=1, paragraphs=1)
+        result = gen_iplum(words=1, paragraphs=1)
         self.assertEqual(len(result.split()), 1, "String is not 1-word long")
         self.assertEqual(
             len(result.split()), 1, "String is not 1-paragraph long")
 
-    def test_generate_loremipsum_8(self):
+    def test_gen_loremipsum_8(self):
         """
         @Test: Create a lorem ipsum string with non-integer words
         @Feature: Lorem Ipsum Generator
@@ -113,9 +113,9 @@ class TestLoremIpsum(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_iplum(words='a')
+            gen_iplum(words='a')
 
-    def test_generate_loremipsum_9(self):
+    def test_gen_loremipsum_9(self):
         """
         @Test: Create a lorem ipsum string with non-integer paragraphs
         @Feature: Lorem Ipsum Generator
@@ -123,9 +123,9 @@ class TestLoremIpsum(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_iplum(paragraphs='a')
+            gen_iplum(paragraphs='a')
 
-    def test_generate_loremipsum_10(self):
+    def test_gen_loremipsum_10(self):
         """
         @Test: Create a lorem ipsum string with random words/paragraphs
         @Feature: Lorem Ipsum Generator
@@ -135,7 +135,7 @@ class TestLoremIpsum(unittest.TestCase):
         for i in range(20):
             words = random.randint(1, 500)
             paragraphs = random.randint(1, 500)
-            result = generate_iplum(
+            result = gen_iplum(
                 words=words, paragraphs=paragraphs)
             self.assertEqual(
                 len(result.split('\n')),

--- a/tests/test_macs.py
+++ b/tests/test_macs.py
@@ -2,7 +2,7 @@
 
 """Tests for MAC generator."""
 
-from fauxfactory import generate_mac
+from fauxfactory import gen_mac
 
 import random
 import re
@@ -15,14 +15,14 @@ mac = re.compile("[0-9a-f]{2}([-:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$")
 class TestMacs(unittest.TestCase):
     """Test MAC generator."""
 
-    def test_generate_mac_1(self):
+    def test_gen_mac_1(self):
         """
         @Test: Generate a MAC address using \":\" as the delimiter
         @Feature: MAC Generator
         @Assert: A MAC address is generated using \":\" as the delimiter
         """
 
-        result = generate_mac()
+        result = gen_mac()
         self.assertTrue(
             len(result.split(":")) == 6,
             "Did not generate a MAC addrss")
@@ -30,14 +30,14 @@ class TestMacs(unittest.TestCase):
             mac.match(result),
             "Did not match regular expression for MAC address")
 
-    def test_generate_mac_2(self):
+    def test_gen_mac_2(self):
         """
         @Test: Generate a MAC address using \":\" as the delimiter
         @Feature: MAC Generator
         @Assert: A MAC address is generated using \":\" as the delimiter
         """
 
-        result = generate_mac(delimiter=":")
+        result = gen_mac(delimiter=":")
         self.assertTrue(
             len(result.split(":")) == 6,
             "Did not generate a MAC addrss")
@@ -45,14 +45,14 @@ class TestMacs(unittest.TestCase):
             mac.match(result),
             "Did not match regular expression for MAC address")
 
-    def test_generate_mac_3(self):
+    def test_gen_mac_3(self):
         """
         @Test: Generate a MAC address using \"-\" as the delimiter
         @Feature: MAC Generator
         @Assert: A MAC address is generated using \"-\" as the delimiter
         """
 
-        result = generate_mac(delimiter="-")
+        result = gen_mac(delimiter="-")
         self.assertTrue(
             len(result.split("-")) == 6,
             "Did not generate a MAC addrss")
@@ -60,7 +60,7 @@ class TestMacs(unittest.TestCase):
             mac.match(result),
             "Did not match regular expression for MAC address")
 
-    def test_generate_mac_4(self):
+    def test_gen_mac_4(self):
         """
         @Test: Generate a MAC address using \".\" as the delimiter
         @Feature: MAC Generator
@@ -68,9 +68,9 @@ class TestMacs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_mac(delimiter=".")
+            gen_mac(delimiter=".")
 
-    def test_generate_mac_5(self):
+    def test_gen_mac_5(self):
         """
         @Test: Generate a MAC address using \" \" as the delimiter
         @Feature: MAC Generator
@@ -78,9 +78,9 @@ class TestMacs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_mac(delimiter=" ")
+            gen_mac(delimiter=" ")
 
-    def test_generate_mac_6(self):
+    def test_gen_mac_6(self):
         """
         @Test: Generate a MAC address using a number as the delimiter
         @Feature: MAC Generator
@@ -88,9 +88,9 @@ class TestMacs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_mac(delimiter=random.randint(0, 10))
+            gen_mac(delimiter=random.randint(0, 10))
 
-    def test_generate_mac_7(self):
+    def test_gen_mac_7(self):
         """
         @Test: Generate a MAC address using a letter as the delimiter
         @Feature: MAC Generator
@@ -98,5 +98,5 @@ class TestMacs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_mac(
+            gen_mac(
                 delimiter=random.choice(string.ascii_letters))

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -3,9 +3,9 @@
 """Tests for all number generators."""
 
 from fauxfactory import (
-    generate_integer,
-    generate_negative_integer,
-    generate_positive_integer,
+    gen_integer,
+    gen_negative_integer,
+    gen_positive_integer,
 )
 
 import sys
@@ -15,18 +15,18 @@ import unittest
 class TestNumbers(unittest.TestCase):
     """Test number generators."""
 
-    def test_generate_integer_1(self):
+    def test_gen_integer_1(self):
         """
         @Test: Create a random integer with no range limits
         @Feature: Numbers Generator
         @Assert: A random integer is created
         """
 
-        result = generate_integer()
+        result = gen_integer()
         self.assertTrue(
             isinstance(result, int), "A valid integer was not generated.")
 
-    def test_generate_integer_2(self):
+    def test_gen_integer_2(self):
         """
         @Test: Create a random integer with set minimum limit
         @Feature: Numbers Generator
@@ -39,7 +39,7 @@ class TestNumbers(unittest.TestCase):
             sys.maxsize = 5
 
             for turn in range(10):
-                result = generate_integer(min_value=1)
+                result = gen_integer(min_value=1)
                 self.assertTrue(
                     result <= sys.maxsize, "Integer is greater than max_value"
                 )
@@ -50,7 +50,7 @@ class TestNumbers(unittest.TestCase):
             # Reset system max int back to original value
             sys.maxsize = old_sys_maxsize
 
-    def test_generate_integer_3(self):
+    def test_gen_integer_3(self):
         """
         @Test: Create a random integer with set maximum limit
         @Feature: Numbers Generator
@@ -64,7 +64,7 @@ class TestNumbers(unittest.TestCase):
             min_value = - sys.maxsize - 1
 
             for turn in range(10):
-                result = generate_integer(max_value=1)
+                result = gen_integer(max_value=1)
                 self.assertTrue(
                     result >= min_value, "Integer is less than min_value"
                 )
@@ -75,7 +75,7 @@ class TestNumbers(unittest.TestCase):
             # Reset system max int back to original value
             sys.maxsize = old_sys_maxsize
 
-    def test_generate_integer_4(self):
+    def test_gen_integer_4(self):
         """
         @Test: Create a random integer with set min/max limits
         @Feature: Numbers Generator
@@ -83,7 +83,7 @@ class TestNumbers(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = generate_integer(
+            result = gen_integer(
                 min_value=1, max_value=3)
             self.assertTrue(
                 result >= 1, "Integer is less than min_value"
@@ -92,7 +92,7 @@ class TestNumbers(unittest.TestCase):
                 result <= 3, "Integer is greater than specified maximum"
             )
 
-    def test_generate_integer_5(self):
+    def test_gen_integer_5(self):
         """
         @Test: Create a random integer with disallowed minimum limit
         @Feature: Numbers Generator
@@ -103,9 +103,9 @@ class TestNumbers(unittest.TestCase):
         low_min = - sys.maxsize - 2
 
         with self.assertRaises(ValueError):
-            generate_integer(min_value=low_min)
+            gen_integer(min_value=low_min)
 
-    def test_generate_integer_6(self):
+    def test_gen_integer_6(self):
         """
         @Test: Create a random integer with disallowed maximum limit
         @Feature: Numbers Generator
@@ -116,9 +116,9 @@ class TestNumbers(unittest.TestCase):
         high_max = sys.maxsize + 1
 
         with self.assertRaises(ValueError):
-            generate_integer(max_value=high_max)
+            gen_integer(max_value=high_max)
 
-    def test_generate_integer_7_0(self):
+    def test_gen_integer_7_0(self):
         """
         @Test: Create a random integer using empty strings as args
         @Feature: Numbers Generator
@@ -126,9 +126,9 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_integer(min_value='')
+            gen_integer(min_value='')
 
-    def test_generate_integer_7_1(self):
+    def test_gen_integer_7_1(self):
         """
         @Test: Create a random integer using empty strings as args
         @Feature: Numbers Generator
@@ -136,9 +136,9 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_integer(max_value='')
+            gen_integer(max_value='')
 
-    def test_generate_integer_7_2(self):
+    def test_gen_integer_7_2(self):
         """
         @Test: Create a random integer using empty strings as args
         @Feature: Numbers Generator
@@ -146,9 +146,9 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_integer(min_value='', max_value='')
+            gen_integer(min_value='', max_value='')
 
-    def test_generate_integer_8_0(self):
+    def test_gen_integer_8_0(self):
         """
         @Test: Create a random integer using whitespace as args
         @Feature: Numbers Generator
@@ -156,9 +156,9 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_integer(min_value=' ')
+            gen_integer(min_value=' ')
 
-    def test_generate_integer_8_1(self):
+    def test_gen_integer_8_1(self):
         """
         @Test: Create a random integer using whitespace as args
         @Feature: Numbers Generator
@@ -166,9 +166,9 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_integer(max_value=' ')
+            gen_integer(max_value=' ')
 
-    def test_generate_integer_8_2(self):
+    def test_gen_integer_8_2(self):
         """
         @Test: Create a random integer using whitespace as args
         @Feature: Numbers Generator
@@ -176,9 +176,9 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_integer(min_value=' ', max_value=' ')
+            gen_integer(min_value=' ', max_value=' ')
 
-    def test_generate_integer_9_0(self):
+    def test_gen_integer_9_0(self):
         """
         @Test: Create a random integer using alpha strings as args
         @Feature: Numbers Generator
@@ -186,9 +186,9 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_integer(min_value='a')
+            gen_integer(min_value='a')
 
-    def test_generate_integer_9_1(self):
+    def test_gen_integer_9_1(self):
         """
         @Test: Create a random integer using alpha strings as args
         @Feature: Numbers Generator
@@ -196,9 +196,9 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_integer(max_value='a')
+            gen_integer(max_value='a')
 
-    def test_generate_integer_9_2(self):
+    def test_gen_integer_9_2(self):
         """
         @Test: Create a random integer using alpha strings as args
         @Feature: Numbers Generator
@@ -206,26 +206,26 @@ class TestNumbers(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_integer(min_value='a', max_value='b')
+            gen_integer(min_value='a', max_value='b')
 
-    def test_generate_positive_integer_1(self):
+    def test_gen_positive_integer_1(self):
         """
         @Test: Create a random positive integer
         @Feature: Numbers Generator
         @Assert: A positive number is created
         """
 
-        result = generate_positive_integer()
+        result = gen_positive_integer()
 
         self.assertTrue(result >= 0, "Generated integer is not positive")
 
-    def test_generate_negative_integer_1(self):
+    def test_gen_negative_integer_1(self):
         """
         @Test: Create a random negative integer
         @Feature: Numbers Generator
         @Assert: A negative number is created
         """
 
-        result = generate_negative_integer()
+        result = gen_negative_integer()
 
         self.assertTrue(result <= 0, "Generated integer is not negative")

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -3,14 +3,14 @@
 """Tests for all string generators."""
 
 from fauxfactory import (
-    generate_alpha,
-    generate_alphanumeric,
-    generate_cjk,
-    generate_html,
-    generate_latin1,
-    generate_numeric_string,
-    generate_string,
-    generate_utf8,
+    gen_alpha,
+    gen_alphanumeric,
+    gen_cjk,
+    gen_html,
+    gen_latin1,
+    gen_numeric_string,
+    gen_string,
+    gen_utf8,
 )
 from sys import version_info
 
@@ -21,18 +21,18 @@ import random
 class TestStrings(unittest.TestCase):
     """Test string generators."""
 
-    def test_generate_alpha_1(self):
+    def test_gen_alpha_1(self):
         """
         @Test: Create alpha string of varied length
         @Feature: String Generator
         @Assert: Alpha string is created
         """
 
-        result = generate_alpha()
+        result = gen_alpha()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
-    def test_generate_alpha_2(self):
+    def test_gen_alpha_2(self):
         """
         @Test: Create alpha string of fixed length
         @Feature: String Generator
@@ -40,13 +40,13 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = generate_alpha(length)
+            result = gen_alpha(length)
             self.assertEqual(
                 len(result),
                 length,
                 "Generate string does not have the expected length")
 
-    def test_generate_alpha_3_0(self):
+    def test_gen_alpha_3_0(self):
         """
         @Test: Create alpha string with zero length
         @Feature: String Generator
@@ -54,9 +54,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alpha(length=0)
+            gen_alpha(length=0)
 
-    def test_generate_alpha_3_1(self):
+    def test_gen_alpha_3_1(self):
         """
         @Test: Create alpha string with zero length
         @Feature: String Generator
@@ -64,9 +64,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alphanumeric(length=0)
+            gen_alphanumeric(length=0)
 
-    def test_generate_alpha_3_2(self):
+    def test_gen_alpha_3_2(self):
         """
         @Test: Create alpha string with zero length
         @Feature: String Generator
@@ -74,9 +74,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_cjk(length=0)
+            gen_cjk(length=0)
 
-    def test_generate_alpha_3_3(self):
+    def test_gen_alpha_3_3(self):
         """
         @Test: Create alpha string with zero length
         @Feature: String Generator
@@ -84,9 +84,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_latin1(length=0)
+            gen_latin1(length=0)
 
-    def test_generate_alpha_3_4(self):
+    def test_gen_alpha_3_4(self):
         """
         @Test: Create alpha string with zero length
         @Feature: String Generator
@@ -94,9 +94,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_numeric_string(length=0)
+            gen_numeric_string(length=0)
 
-    def test_generate_alpha_4(self):
+    def test_gen_alpha_4(self):
         """
         @Test: Create alpha string with negative length
         @Feature: String Generator
@@ -104,9 +104,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alpha(length=-1)
+            gen_alpha(length=-1)
 
-    def test_generate_alpha_5(self):
+    def test_gen_alpha_5(self):
         """
         @Test: Create alpha string with None length
         @Feature: String Generator
@@ -114,9 +114,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alpha(length=None)
+            gen_alpha(length=None)
 
-    def test_generate_alpha_6(self):
+    def test_gen_alpha_6(self):
         """
         @Test: Create alpha string with empty string length
         @Feature: String Generator
@@ -124,9 +124,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alpha(length='')
+            gen_alpha(length='')
 
-    def test_generate_alpha_7(self):
+    def test_gen_alpha_7(self):
         """
         @Test: Create alpha string with white space length
         @Feature: String Generator
@@ -134,9 +134,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alpha(length=' ')
+            gen_alpha(length=' ')
 
-    def test_generate_alpha_8(self):
+    def test_gen_alpha_8(self):
         """
         @Test: Create alpha string with alpha string length
         @Feature: String Generator
@@ -144,31 +144,31 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alpha(length='a')
+            gen_alpha(length='a')
 
-    def test_generate_alpha_9(self):
+    def test_gen_alpha_9(self):
         """
         @Test: Create alpha string of varied length
         @Feature: String Generator
         @Assert: Alpha string is created
         """
 
-        result = generate_string('alpha', 15)
+        result = gen_string('alpha', 15)
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
-    def test_generate_alphanumeric_1(self):
+    def test_gen_alphanumeric_1(self):
         """
         @Test: Create alphanumeric string of varied length
         @Feature: String Generator
         @Assert: Alphanumeric string is generated
         """
 
-        result = generate_alphanumeric()
+        result = gen_alphanumeric()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
-    def test_generate_alphanumeric_2(self):
+    def test_gen_alphanumeric_2(self):
         """
         @Test: Create alphanumeric string of fixed length
         @Feature: String Generator
@@ -176,13 +176,13 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = generate_alphanumeric(length)
+            result = gen_alphanumeric(length)
             self.assertEqual(
                 len(result),
                 length,
                 "Generate string does not have the expected length")
 
-    def test_generate_alphanumeric_3(self):
+    def test_gen_alphanumeric_3(self):
         """
         @Test: Create alphanumeric string with zero length
         @Feature: String Generator
@@ -190,9 +190,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alphanumeric(length=0)
+            gen_alphanumeric(length=0)
 
-    def test_generate_alphanumeric_4(self):
+    def test_gen_alphanumeric_4(self):
         """
         @Test: Create alphanumeric string with negative length
         @Feature: String Generator
@@ -200,9 +200,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alphanumeric(length=-1)
+            gen_alphanumeric(length=-1)
 
-    def test_generate_alphanumeric_5(self):
+    def test_gen_alphanumeric_5(self):
         """
         @Test: Create alphanumeric string with None length
         @Feature: String Generator
@@ -210,9 +210,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alphanumeric(length=None)
+            gen_alphanumeric(length=None)
 
-    def test_generate_alphanumeric_6(self):
+    def test_gen_alphanumeric_6(self):
         """
         @Test: Create alphanumeric string with empty string length
         @Feature: String Generator
@@ -220,9 +220,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alphanumeric(length='')
+            gen_alphanumeric(length='')
 
-    def test_generate_alphanumeric_7(self):
+    def test_gen_alphanumeric_7(self):
         """
         @Test: Create alphanumeric string with white space length
         @Feature: String Generator
@@ -230,9 +230,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alphanumeric(length=' ')
+            gen_alphanumeric(length=' ')
 
-    def test_generate_alphanumeric_8(self):
+    def test_gen_alphanumeric_8(self):
         """
         @Test: Create alphanumeric string with alpha string length
         @Feature: String Generator
@@ -240,20 +240,20 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_alphanumeric(length='a')
+            gen_alphanumeric(length='a')
 
-    def test_generate_cjk_1(self):
+    def test_gen_cjk_1(self):
         """
         @Test: Create CJK string of varied length
         @Feature: String Generator
         @Assert: CJK string is generated
         """
 
-        result = generate_cjk()
+        result = gen_cjk()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
-    def test_generate_cjk_2(self):
+    def test_gen_cjk_2(self):
         """
         @Test: Create CJK string of fixed length
         @Feature: String Generator
@@ -261,13 +261,13 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = generate_cjk(length)
+            result = gen_cjk(length)
             self.assertEqual(
                 len(result),
                 length,
                 "Generate string does not have the expected length")
 
-    def test_generate_cjk_3(self):
+    def test_gen_cjk_3(self):
         """
         @Test: Create CJK string with zero length
         @Feature: String Generator
@@ -275,9 +275,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_cjk(length=0)
+            gen_cjk(length=0)
 
-    def test_generate_cjk_4(self):
+    def test_gen_cjk_4(self):
         """
         @Test: Create CJK string with negative length
         @Feature: String Generator
@@ -285,9 +285,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_cjk(length=-1)
+            gen_cjk(length=-1)
 
-    def test_generate_cjk_5(self):
+    def test_gen_cjk_5(self):
         """
         @Test: Create CJK string with None length
         @Feature: String Generator
@@ -295,9 +295,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_cjk(length=None)
+            gen_cjk(length=None)
 
-    def test_generate_cjk_6(self):
+    def test_gen_cjk_6(self):
         """
         @Test: Create CJK string with empty string length
         @Feature: String Generator
@@ -305,9 +305,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_cjk(length='')
+            gen_cjk(length='')
 
-    def test_generate_cjk_7(self):
+    def test_gen_cjk_7(self):
         """
         @Test: Create CJK string with white space length
         @Feature: String Generator
@@ -315,9 +315,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_cjk(length=' ')
+            gen_cjk(length=' ')
 
-    def test_generate_cjk_8(self):
+    def test_gen_cjk_8(self):
         """
         @Test: Create CJK string with alpha string length
         @Feature: String Generator
@@ -325,33 +325,33 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_cjk(length='a')
+            gen_cjk(length='a')
 
-    def test_generate_cjk_9(self):
+    def test_gen_cjk_9(self):
         """
         @Test: Create CJK string of varied length
         @Feature: String Generator
         @Assert: CJK string is generated
         """
 
-        result = generate_string('cjk', 15)
+        result = gen_string('cjk', 15)
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
-    def test_generate_utf8_1(self):
+    def test_gen_utf8_1(self):
         """
         @Test: Create a unicode string.
         @Feature: String Generator
         @Assert: A unicode string is generated.
         """
 
-        result = generate_string('utf8', 5)
+        result = gen_string('utf8', 5)
         if version_info[0] == 2:
             self.assertTrue(isinstance(result, unicode))  # flake8:noqa
         else:
             self.assertTrue(isinstance(result, str))
 
-    def test_generate_utf8_2(self):
+    def test_gen_utf8_2(self):
         """
         @Test: Create a unicode string and specify a length.
         @Feature: String Generator
@@ -360,11 +360,11 @@ class TestStrings(unittest.TestCase):
 
         length = random.randint(1, 100)
         self.assertEqual(
-            len(generate_string('utf8', length)),
+            len(gen_string('utf8', length)),
             length
         )
 
-    def test_generate_utf8_3(self):
+    def test_gen_utf8_3(self):
         """
         @Test: Create a unicode string and specify an invalid length.
         @Feature: String Generator
@@ -372,20 +372,20 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_string('utf8', 'foo')
+            gen_string('utf8', 'foo')
 
-    def test_generate_latin1_1(self):
+    def test_gen_latin1_1(self):
         """
         @Test: Create latin1 string of varied length
         @Feature: String Generator
         @Assert: Latin1 string is generated
         """
 
-        result = generate_latin1()
+        result = gen_latin1()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
-    def test_generate_latin1_2(self):
+    def test_gen_latin1_2(self):
         """
         @Test: Create latin1 string of fixed length
         @Feature: String Generator
@@ -393,13 +393,13 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = generate_latin1(length)
+            result = gen_latin1(length)
             self.assertEqual(
                 len(result),
                 length,
                 "Generate string does not have the expected length")
 
-    def test_generate_latin1_3(self):
+    def test_gen_latin1_3(self):
         """
         @Test: Create latin1 string with zero length
         @Feature: String Generator
@@ -407,9 +407,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_latin1(length=0)
+            gen_latin1(length=0)
 
-    def test_generate_latin1_4(self):
+    def test_gen_latin1_4(self):
         """
         @Test: Create latin1 string with negative length
         @Feature: String Generator
@@ -417,9 +417,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_latin1(length=-1)
+            gen_latin1(length=-1)
 
-    def test_generate_latin1_5(self):
+    def test_gen_latin1_5(self):
         """
         @Test: Create latin1 string with None length
         @Feature: String Generator
@@ -427,9 +427,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_latin1(length=None)
+            gen_latin1(length=None)
 
-    def test_generate_latin1_6(self):
+    def test_gen_latin1_6(self):
         """
         @Test: Create latin1 string with empty string length
         @Feature: String Generator
@@ -437,9 +437,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_latin1(length='')
+            gen_latin1(length='')
 
-    def test_generate_latin1_7(self):
+    def test_gen_latin1_7(self):
         """
         @Test: Create latin1 string with white space length
         @Feature: String Generator
@@ -447,9 +447,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_latin1(length=' ')
+            gen_latin1(length=' ')
 
-    def test_generate_latin1_8(self):
+    def test_gen_latin1_8(self):
         """
         @Test: Create latin1 string with alpha string length
         @Feature: String Generator
@@ -457,31 +457,31 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_latin1(length='a')
+            gen_latin1(length='a')
 
-    def test_generate_latin1_9(self):
+    def test_gen_latin1_9(self):
         """
         @Test: Create latin1 string of varied length
         @Feature: String Generator
         @Assert: Latin1 string is generated
         """
 
-        result = generate_string('latin1', 15)
+        result = gen_string('latin1', 15)
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
-    def test_generate_numeric_string_1(self):
+    def test_gen_numeric_string_1(self):
         """
         @Test: Create numeric string of varied length
         @Feature: String Generator
         @Assert: Latin1 string is not created due to value error
         """
 
-        result = generate_numeric_string()
+        result = gen_numeric_string()
         self.assertTrue(
             len(result) > 0, "Empty string was generated")
 
-    def test_generate_numeric_string_2(self):
+    def test_gen_numeric_string_2(self):
         """
         @Test: Create numeric string of fixed length
         @Feature: String Generator
@@ -489,13 +489,13 @@ class TestStrings(unittest.TestCase):
         """
 
         for length in range(2, 12, 2):
-            result = generate_numeric_string(length)
+            result = gen_numeric_string(length)
             self.assertEqual(
                 len(result),
                 length,
                 "Generate string does not have the expected length")
 
-    def test_generate_numeric_string_3(self):
+    def test_gen_numeric_string_3(self):
         """
         @Test: Create numeric string with zero length
         @Feature: String Generator
@@ -503,9 +503,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_numeric_string(length=0)
+            gen_numeric_string(length=0)
 
-    def test_generate_numeric_string_4(self):
+    def test_gen_numeric_string_4(self):
         """
         @Test: Create numeric string with negative length
         @Feature: String Generator
@@ -513,9 +513,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_numeric_string(length=-1)
+            gen_numeric_string(length=-1)
 
-    def test_generate_numeric_string_5(self):
+    def test_gen_numeric_string_5(self):
         """
         @Test: Create numeric string with None length
         @Feature: String Generator
@@ -523,9 +523,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_numeric_string(length=None)
+            gen_numeric_string(length=None)
 
-    def test_generate_numeric_string_6(self):
+    def test_gen_numeric_string_6(self):
         """
         @Test: Create numeric string with empty string length
         @Feature: String Generator
@@ -533,9 +533,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_numeric_string(length='')
+            gen_numeric_string(length='')
 
-    def test_generate_numeric_string_7(self):
+    def test_gen_numeric_string_7(self):
         """
         @Test: Create numeric string with white space length
         @Feature: String Generator
@@ -543,9 +543,9 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_numeric_string(length=' ')
+            gen_numeric_string(length=' ')
 
-    def test_generate_numeric_string_8(self):
+    def test_gen_numeric_string_8(self):
         """
         @Test: Create numeric string with alpha string length
         @Feature: String Generator
@@ -553,43 +553,43 @@ class TestStrings(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_numeric_string(length='a')
+            gen_numeric_string(length='a')
 
-    def test_generate_string(self):
+    def test_gen_string(self):
         """
         @Test: Create alphanumeric string with given lenght
         @Feature: String Generator
         @Assert: Alphanumeric string is created with size of 15 chars
         """
-        alphanumeric_string = generate_string('alphanumeric', 15)
+        alphanumeric_string = gen_string('alphanumeric', 15)
         self.assertEqual(15, len(alphanumeric_string),
                          "Generated string does not have the expected length")
 
-    def test_generate_string2(self):
+    def test_gen_string2(self):
         """
         @Test: Create alpha string with given length
         @Feature: String generator
         @Assert: Alpha string is not created due to the lack of parameter type
         """
         with self.assertRaises(Exception):
-            generate_string('', 15)
+            gen_string('', 15)
 
-    def test_generate_string3(self):
+    def test_gen_string3(self):
         """
         @Test: Create a numeric string with the given length
         @Feature: String generator
         @Assert: Numeric string is created with size of 20 chars
         """
-        numeric_string = generate_string('numeric', 20)
+        numeric_string = gen_string('numeric', 20)
         self.assertEqual(20, len(numeric_string),
                          "Generated string does not have the expected length")
 
-    def test_generate_string4(self):
+    def test_gen_string4(self):
         """
         @Test: Create a html string with the given length
         @Feature: String generator
         @Assert: HTML string is created and should greater than given length
         """
-        html_string = generate_string('html', 10)
+        html_string = gen_string('html', 10)
         self.assertTrue(len(html_string) > 10,
                         "Generated string does not have the expected length")

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -2,7 +2,7 @@
 
 """Tests for Time generator."""
 
-from fauxfactory import generate_time
+from fauxfactory import gen_time
 
 import unittest
 import datetime
@@ -11,7 +11,7 @@ import datetime
 class TestTime(unittest.TestCase):
     """Test Time generator."""
 
-    def test_generate_uuid_1(self):
+    def test_gen_uuid_1(self):
         """
         @Test: Create a random UUID value
         @Feature: UUID Generator
@@ -19,7 +19,7 @@ class TestTime(unittest.TestCase):
         """
 
         for turn in range(100):
-            result = generate_time()
+            result = gen_time()
             self.assertIsInstance(
                 result, datetime.time,
                 "A valid Time value was not generated.")

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -5,11 +5,11 @@
 import unittest
 
 from fauxfactory import (
-    generate_alpha,
-    generate_alphanumeric,
-    generate_cjk,
-    generate_numeric_string,
-    generate_url,
+    gen_alpha,
+    gen_alphanumeric,
+    gen_cjk,
+    gen_numeric_string,
+    gen_url,
 )
 from fauxfactory.constants import SCHEMES
 
@@ -17,7 +17,7 @@ from fauxfactory.constants import SCHEMES
 class TestURLs(unittest.TestCase):
     """Test URL generator."""
 
-    def test_generate_url_1(self):
+    def test_gen_url_1(self):
         """
         @Test: Create a random URL
         @Feature: URL Generator
@@ -25,7 +25,7 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = generate_url()
+            result = gen_url()
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -34,7 +34,7 @@ class TestURLs(unittest.TestCase):
                 "URL does not start with a valid scheme"
             )
 
-    def test_generate_url_2(self):
+    def test_gen_url_2(self):
         """
         @Test: Create a random URL with http scheme
         @Feature: URL Generator
@@ -42,7 +42,7 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = generate_url(scheme='http')
+            result = gen_url(scheme='http')
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -51,7 +51,7 @@ class TestURLs(unittest.TestCase):
                 "URL does not start with http"
             )
 
-    def test_generate_url_3(self):
+    def test_gen_url_3(self):
         """
         @Test: Create a random URL with https scheme
         @Feature: URL Generator
@@ -59,7 +59,7 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = generate_url(scheme='https')
+            result = gen_url(scheme='https')
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -68,7 +68,7 @@ class TestURLs(unittest.TestCase):
                 "URL does not start with https"
             )
 
-    def test_generate_url_4(self):
+    def test_gen_url_4(self):
         """
         @Test: Create a random URL with ftp scheme
         @Feature: URL Generator
@@ -76,7 +76,7 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            result = generate_url(scheme='ftp')
+            result = gen_url(scheme='ftp')
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -85,7 +85,7 @@ class TestURLs(unittest.TestCase):
                 "URL does not start with ftp"
             )
 
-    def test_generate_url_5(self):
+    def test_gen_url_5(self):
         """
         @Test: Create a random URL with invalid scheme
         @Feature: URL Generator
@@ -93,11 +93,11 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            scheme = generate_alphanumeric()
+            scheme = gen_alphanumeric()
             with self.assertRaises(ValueError):
-                generate_url(scheme=scheme)
+                gen_url(scheme=scheme)
 
-    def test_generate_url_6(self):
+    def test_gen_url_6(self):
         """
         @Test: Create a random URL with valid subdomain
         @Feature: URL Generator
@@ -105,8 +105,8 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            subdomain = generate_alphanumeric()
-            result = generate_url(subdomain=subdomain)
+            subdomain = gen_alphanumeric()
+            result = gen_url(subdomain=subdomain)
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -118,19 +118,19 @@ class TestURLs(unittest.TestCase):
                 domain[0] == subdomain
             )
 
-    def test_generate_url_7(self):
+    def test_gen_url_7(self):
         """
         @Test: Create a random URL with empty subdomain
         @Feature: URL Generator
         @Assert: URL should be created with a random subdomain
         """
 
-        result = generate_url(subdomain='')
+        result = gen_url(subdomain='')
         self.assertTrue(
             len(result) > 0,
             "A valid URL was not generated.")
 
-    def test_generate_url_8(self):
+    def test_gen_url_8(self):
         """
         @Test: Create a random URL with whitespace subdomain
         @Feature: URL Generator
@@ -138,9 +138,9 @@ class TestURLs(unittest.TestCase):
         """
 
         with self.assertRaises(ValueError):
-            generate_url(subdomain=" ")
+            gen_url(subdomain=" ")
 
-    def test_generate_url_9(self):
+    def test_gen_url_9(self):
         """
         @Test: Create a random URL with invalid subdomain
         @Feature: URL Generator
@@ -148,11 +148,11 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            subdomain = generate_cjk()
+            subdomain = gen_cjk()
             with self.assertRaises(ValueError):
-                generate_url(subdomain=subdomain)
+                gen_url(subdomain=subdomain)
 
-    def test_generate_url_10(self):
+    def test_gen_url_10(self):
         """
         @Test: Create a random URL with valid TLDS
         @Feature: URL Generator
@@ -160,8 +160,8 @@ class TestURLs(unittest.TestCase):
         """
 
         for turn in range(10):
-            tlds = generate_alpha(length=3)
-            result = generate_url(tlds=tlds)
+            tlds = gen_alpha(length=3)
+            result = gen_url(tlds=tlds)
             self.assertTrue(
                 len(result) > 0,
                 "A valid URL was not generated.")
@@ -170,7 +170,7 @@ class TestURLs(unittest.TestCase):
                 "URL does not have the TLDS specified"
             )
 
-    def test_generate_url_11(self):
+    def test_gen_url_11(self):
         """
         @Test: Create a random URL with numeric TLDS
         @Feature: URL Generator
@@ -179,10 +179,10 @@ class TestURLs(unittest.TestCase):
 
         for turn in range(10):
             with self.assertRaises(ValueError):
-                tlds = generate_numeric_string(length=3)
-                generate_url(tlds=tlds)
+                tlds = gen_numeric_string(length=3)
+                gen_url(tlds=tlds)
 
-    def test_generate_url_12(self):
+    def test_gen_url_12(self):
         """
         @Test: Create a random URL with whitespace TLDS
         @Feature: URL Generator
@@ -191,4 +191,4 @@ class TestURLs(unittest.TestCase):
 
         for turn in range(10):
             with self.assertRaises(ValueError):
-                generate_url(tlds=" ")
+                gen_url(tlds=" ")

--- a/tests/test_uuids.py
+++ b/tests/test_uuids.py
@@ -2,7 +2,7 @@
 
 """Tests for UUID generator."""
 
-from fauxfactory import generate_uuid
+from fauxfactory import gen_uuid
 
 import unittest
 
@@ -10,7 +10,7 @@ import unittest
 class TestUUID(unittest.TestCase):
     """Test UUID generator."""
 
-    def test_generate_uuid_1(self):
+    def test_gen_uuid_1(self):
         """
         @Test: Create a random UUID4 value
         @Feature: UUID Generator
@@ -18,7 +18,7 @@ class TestUUID(unittest.TestCase):
         """
 
         for turn in range(100):
-            result = generate_uuid()
+            result = gen_uuid()
             self.assertGreater(
                 len(result), 0,
                 "A valid UUID value was not generated.")


### PR DESCRIPTION
Rename all the generator functions. Use the prefix "gen_" instead of
"generate_". For example, `generate_date` is now `gen_date`.

Make helper functions private. Rename `codify` to `_make_unicode` and
`is_positive_int` to `_is_positive_int`.

Silence some pylint and flake8 warnings, either by fixing the relevant error
(e.g. use better names for unused variables) or silencing the relevant error
(e.g. the use of the Python 2 keyword "unicode").
