### PR TITLE
Polish the testing process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
+  - 2.7
+  - 3.3
+  - 3.4
 install:
-  "pip install nose nose-cov coveralls"
+  pip install -r requirements-optional.txt
 script:
-  nosetests --verbosity=2 --with-coverage --cover-package fauxfactory tests/
+  make test-all
 after_success:
   coveralls
 notifications:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -113,7 +113,15 @@ Contribute
 
 #. Fork `the repository`_ on GitHub and make some changes. Make sure to add
    yourself to `AUTHORS`_.
-#. Write tests for your changes.
+#. Install the development requirements. ``pip install -r requirements.txt``.
+#.  Test your changes.
+
+    #. Run ``make test-all`` and make sure nothing has broken.
+    #. Run ``coverage report --show-missing`` to check for untested code.
+    #. Add tests to the ``tests/`` directory if appropriate.
+
+    Repeat this cycle as needed.
+
 #. Send a pull request and bug the maintainer until it gets merged and
    published. :)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-Jinja2==2.7.2
-MarkupSafe==0.19
-Pygments==1.6
-Sphinx==1.2.2
-argparse==1.2.1
-docutils==0.11
-nose==1.3.1
-sphinx-rtd-theme==0.1.6
-wsgiref==0.1.2

--- a/makefile
+++ b/makefile
@@ -1,4 +1,6 @@
-define run-doctest =
+unittest-args = -m unittest discover --start-directory tests --top-level-directory .
+
+define doctest-cmd =
 cd docs && $(MAKE) doctest
 endef
 
@@ -7,19 +9,23 @@ help:
 	@echo "  docs-clean    Remove documentation."
 	@echo "  docs-doctest  Check code samples in the documentation."
 	@echo "  docs-html     Compile documentation to HTML."
-	@echo "  test          Run unit tests and doctests."
+	@echo "  test          Run unit tests."
+	@echo "  test-all      Run unit tests and doctests, measure coverage."
 
 docs-clean:
 	cd docs && $(MAKE) clean
 
 docs-doctest:
-	$(run-doctest)
+	$(doctest-cmd)
 
 docs-html:
 	cd docs && $(MAKE) html
 
 test:
-	python -m unittest discover --start-directory tests --top-level-directory .
-	$(run-doctest)
+	python $(unittest-args)
 
-.PHONY: help docs-clean docs-doctest docs-html test
+test-all:
+	coverage run $(unittest-args)
+	$(doctest-cmd)
+
+.PHONY: help docs-clean docs-doctest docs-html test test-all

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,3 @@
+coverage
+coveralls
+Sphinx


### PR DESCRIPTION
Change how Travis executes tests:
- Make Travis install requirements from `requirements-optional.txt`. Formerly,
  Travis would install a set of requirements listed in `.travis.yml`.
- Make Travis run unit tests, collect coverage statistics and run doctests by
  calling make. Formerly, Travis executed unit tests and collected coverage
  statistics by executing a command listed in `.travis.yml`, and Travis did not
  execute doctests at all.

Update the makefile to support these changes.
- Add the command `test-all`.
- Trim down the command `test`.

Drop `docs/requirements.txt`, as it appears to be useless. Add
`requirements.txt`.

Flesh out the contribution guidelines in the readme.
