### PR TITLE
Implement backward compatiblility

### DIFF
--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -698,3 +698,109 @@ def gen_html(length=5):
         html_tag, gen_string("alpha", length), html_tag)
 
     return _make_unicode(output_string)
+
+
+# Backward Compatibility ------------------------------------------------------
+
+
+def codify(data):
+    # (missing-docstring) pylint:disable=C0111
+    return _make_unicode(data)
+
+
+class FauxFactory(object):
+    # This issue is no longer relevant, as the class has been turned into a set
+    # of functions.
+    # (too-many-public-methods) pylint:disable=R0904
+    #
+    # This code is not imported when `from fauxfactory import *` is called, nor
+    # does this code show up in Sphinx's output. See `__all__`.
+    # (missing-docstring) pylint:disable=C0111
+
+    @classmethod
+    def generate_string(cls, str_type, length):
+        return gen_string(str_type, length)
+
+    @classmethod
+    def generate_alpha(cls, length=5):
+        return gen_alpha(length)
+
+    @classmethod
+    def generate_alphanumeric(cls, length=5):
+        return gen_alphanumeric(length)
+
+    @classmethod
+    def generate_boolean(cls):
+        return gen_boolean()
+
+    @classmethod
+    def generate_choice(cls, choices):
+        return gen_choice(choices)
+
+    @classmethod
+    def generate_cjk(cls, length=5):
+        return gen_cjk(length)
+
+    @classmethod
+    def generate_date(cls, min_date=None, max_date=None):
+        return gen_date(min_date, max_date)
+
+    @classmethod
+    def generate_datetime(cls, min_date=None, max_date=None):
+        return gen_datetime(min_date, max_date)
+
+    @classmethod
+    def generate_email(cls, name=None, domain=None, tlds=None):
+        return gen_email(name, domain, tlds)
+
+    @classmethod
+    def generate_integer(cls, min_value=None, max_value=None):
+        return gen_integer(min_value, max_value)
+
+    @classmethod
+    def generate_iplum(cls, words=None, paragraphs=None):
+        return gen_iplum(words, paragraphs)
+
+    @classmethod
+    def generate_latin1(cls, length=5):
+        return gen_latin1(length)
+
+    @classmethod
+    def generate_negative_integer(cls):
+        return gen_negative_integer()
+
+    @classmethod
+    def generate_ipaddr(cls, ip3=False, ipv6=False):
+        return gen_ipaddr(ip3, ipv6)
+
+    @classmethod
+    def generate_mac(cls, delimiter=":"):
+        return gen_mac(delimiter)
+
+    @classmethod
+    def generate_numeric_string(cls, length=5):
+        return gen_numeric_string(length)
+
+    @classmethod
+    def generate_positive_integer(cls):
+        return gen_integer()
+
+    @classmethod
+    def generate_time(cls):
+        return gen_time()
+
+    @classmethod
+    def generate_url(cls, scheme=None, subdomain=None, tlds=None):
+        return gen_url(scheme, subdomain, tlds)
+
+    @classmethod
+    def generate_utf8(cls, length=5):
+        return gen_utf8(length)
+
+    @classmethod
+    def generate_uuid(cls):
+        return gen_uuid()
+
+    @classmethod
+    def generate_html(cls, length=5):
+        return gen_html(length)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,59 @@
+"""Tests to help ensure that FauxFactory remains backward compatible."""
+from fauxfactory import codify, FauxFactory
+from functools import partial
+from unittest import TestCase
+import datetime
+# (too-many-public-methods) pylint:disable=R0904
+
+
+class FauxFactoryTestCase(TestCase):
+    """Call methods on class ``FauxFactory``."""
+    def test_not_none(self):
+        """Call every method on ``FauxFactory`` and provide arguments.
+
+        This test does very little: it simply calls each method on
+        ``FauxFactory``, provides a value for each possible argument, and
+        asserts that the return value is not ``None``. This is not amazingly
+        useful. However, it does provide a basic sanity check. It tells us that
+        each wrapper method:
+
+        * can run without raising an exception,
+        * can accept an appropriate number of arguments, and
+        * returns an "interesting" value.
+
+        """
+        generators = (
+            partial(codify, 'make-me-unicode'),
+            partial(FauxFactory.generate_string, 'alpha', 3),
+            partial(FauxFactory.generate_alpha, 3),
+            partial(FauxFactory.generate_alphanumeric, 3),
+            FauxFactory.generate_boolean,
+            partial(FauxFactory.generate_choice, (1, 2)),
+            partial(FauxFactory.generate_cjk, 3),
+            partial(
+                FauxFactory.generate_date,
+                datetime.date.today() - datetime.timedelta(1),
+                datetime.date.today()
+            ),
+            partial(
+                FauxFactory.generate_datetime,
+                datetime.datetime.now() - datetime.timedelta(1),
+                datetime.datetime.today()
+            ),
+            partial(FauxFactory.generate_email, 'Alice', 'example', 'com'),
+            partial(FauxFactory.generate_integer, 1, 10),
+            partial(FauxFactory.generate_iplum, 1, 1),
+            partial(FauxFactory.generate_latin1, 3),
+            FauxFactory.generate_negative_integer,
+            partial(FauxFactory.generate_ipaddr, True, True),
+            partial(FauxFactory.generate_mac, '-'),
+            partial(FauxFactory.generate_numeric_string, 3),
+            FauxFactory.generate_positive_integer,
+            FauxFactory.generate_time,
+            partial(FauxFactory.generate_url, 'ftp', 'example', 'com'),
+            partial(FauxFactory.generate_utf8, 3),
+            FauxFactory.generate_uuid,
+            partial(FauxFactory.generate_html, 3),
+        )
+        for generator in generators:
+            self.assertIsNotNone(generator())


### PR DESCRIPTION
Create a class `FauxFactory`. Provide it with a set of public class methods and
make them call the equivalent new-style functions. Also provide a `codify`
function that wraps the new `_make_unicode` function.

Provide a basic set of sanity tests for these wrappers.

Do not alter the module-wide variable `__all__`. This prevents the compatiblity
code from showing up in Sphinx-generated documentation or being imported by
`from fauxfactory import *`.
