### PR TITLE
Raise ``ValueError`` for ``gen_string`` function.

### DIFF
--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -80,7 +80,7 @@ def gen_string(str_type, length):
     :param str str_type: The type of string which should be generated.
     :param int length: The length of the generated string. Must be 1 or
         greater.
-    :raises: ``Exception`` if an invalid ``str_type`` is specified.
+    :raises: ``ValueError`` if an invalid ``str_type`` is specified.
     :returns: A string.
     :rtype: str
 
@@ -106,7 +106,7 @@ def gen_string(str_type, length):
     }
     str_type_lower = str_type.lower()  # do not modify user data
     if str_type_lower not in str_types_functions.keys():
-        raise Exception(  # FIXME: Raise a more specific exception.
+        raise ValueError(
             '{0} is not a supported string type. Valid string types are {1}.'
             ''.format(str_type_lower, u','.join(str_types_functions.keys()))
         )
@@ -170,7 +170,7 @@ def gen_choice(choices):
     """Returns a random choice from the available choices.
 
     :param list choices: List of choices from which select a random value.
-    :raises: ``Exception`` if ``choices`` is ``None`` or not ``Iterable`` or
+    :raises: ``ValueError`` if ``choices`` is ``None`` or not ``Iterable`` or
         a ``dict``.
     :returns: A random element from ``choices``.
 

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -593,3 +593,12 @@ class TestStrings(unittest.TestCase):
         html_string = gen_string('html', 10)
         self.assertTrue(len(html_string) > 10,
                         "Generated string does not have the expected length")
+
+    def test_gen_string5(self):
+        """@Test: Call ``gen_string`` with an invalid string type.
+        @Feature: String generator
+        @Assert: ``ValueError`` is raised.
+        """
+        invalid_string_type = gen_string('alpha', 10)
+        with self.assertRaises(ValueError):
+            gen_string(invalid_string_type, 10)


### PR DESCRIPTION
If an invalid string type is requested from `gen_string`, raise
`ValueError` instead of a generic `Exception`. Fixes issue #30.
