### PR TITLE
Cleanly separate readme from full documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,40 @@
-docs/index.rst
+FauxFactory
+===========
+
+.. image:: https://travis-ci.org/omaciel/fauxfactory.png?branch=master
+   :target: https://travis-ci.org/omaciel/fauxfactory
+   :alt: Build Status
+
+.. image:: https://pypip.in/py_versions/fauxfactory/badge.png
+   :target: https://pypi.python.org/pypi/fauxfactory
+   :alt: Python Compatibility
+
+.. image:: https://badge.fury.io/py/fauxfactory.png
+   :target: http://badge.fury.io/py/fauxfactory
+   :alt: Current Version
+
+.. image:: https://pypip.in/d/fauxfactory/badge.png
+   :target: https://crate.io/packages/fauxfactory/
+   :alt: Download Statistics
+
+.. image:: https://coveralls.io/repos/omaciel/fauxfactory/badge.png?branch=master
+   :target: https://coveralls.io/r/omaciel/fauxfactory?branch=master
+   :alt: Test Coverage
+
+.. image:: https://pypip.in/license/fauxfactory/badge.png
+   :target: https://pypi.python.org/pypi/fauxfactory/
+   :alt: License
+
+**FauxFactory** generates random data for your automated tests easily!
+
+There are times when you're writing tests for your application when you need to
+pass random, non-specific data to the areas you are testing. For these scenarios
+when all you need is a random string, numbers, dates, times, email address, IP,
+etc, then FauxFactory can help!
+
+The `full documentation
+<http://fauxfactory.readthedocs.org/en/latest/index.html>`_ is available on
+ReadTheDocs. It can also be generated locally::
+
+    pip install -r requirements-optional.txt
+    make docs-html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,30 +1,6 @@
 FauxFactory
 ===========
 
-.. image:: https://travis-ci.org/omaciel/fauxfactory.png?branch=master
-   :target: https://travis-ci.org/omaciel/fauxfactory
-   :alt: Build Status
-
-.. image:: https://pypip.in/py_versions/fauxfactory/badge.png
-   :target: https://pypi.python.org/pypi/fauxfactory
-   :alt: Python Compatibility
-
-.. image:: https://badge.fury.io/py/fauxfactory.png
-   :target: http://badge.fury.io/py/fauxfactory
-   :alt: Current Version
-
-.. image:: https://pypip.in/d/fauxfactory/badge.png
-   :target: https://crate.io/packages/fauxfactory/
-   :alt: Download Statistics
-
-.. image:: https://coveralls.io/repos/omaciel/fauxfactory/badge.png?branch=master
-   :target: https://coveralls.io/r/omaciel/fauxfactory?branch=master
-   :alt: Test Coverage
-
-.. image:: https://pypip.in/license/fauxfactory/badge.png
-   :target: https://pypi.python.org/pypi/fauxfactory/
-   :alt: License
-
 **FauxFactory** generates random data for your automated tests easily!
 
 There are times when you're writing tests for your application when you need to


### PR DESCRIPTION
Make the readme a real file, instead of a link to `docs/index.rst`. Give the
readme a summary of the project, and include instructions for finding the rest
of the documentation.

Remove the non-local image references from `docs/index.rst`. This silences the
remaining Sphinx warnings.
