### PR TITLE
Display deprecation warning for ``FauxFactory``.

### DIFF
--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -32,6 +32,7 @@ import re
 import string
 import sys
 import uuid
+import warnings
 
 from collections import Iterable
 from fauxfactory.constants import (
@@ -39,7 +40,7 @@ from fauxfactory.constants import (
     MAX_YEARS, MIN_YEARS,
     SCHEMES, SUBDOMAINS, TLDS
 )
-
+from functools import wraps
 
 # Private Functions -----------------------------------------------------------
 
@@ -677,6 +678,29 @@ def gen_html(length=10):
 # Backward Compatibility ------------------------------------------------------
 
 
+# Code borrowed from http://code.activestate.com/recipes/391367-deprecated/
+def deprecated(func):
+    """A decorator used to mark functions as deprecated. It will result in
+    a warning being emmitted when the function is used."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Function name
+        name = func.__name__
+        # New function name
+        # Check if we are dealing with ``codify``
+        if name == 'codify':
+            new_name = '_make_unicode'
+        else:
+            new_name = func.__name__.replace('generate', 'gen')
+        warn_message = ("Function {0} is now deprecated! Please update your "
+            "your code to use the {1} function instead.")
+        warnings.warn(warn_message.format(name, new_name), category=Warning)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@deprecated
 def codify(data):
     # (missing-docstring) pylint:disable=C0111
     return _make_unicode(data)
@@ -691,90 +715,117 @@ class FauxFactory(object):
     # does this code show up in Sphinx's output. See `__all__`.
     # (missing-docstring) pylint:disable=C0111
 
+    warnings.warn(
+        'The FauxFactory class is deprecated. Please use functions from the'
+        ' fauxfactory module instead.',
+        category=Warning)
+
     @classmethod
+    @deprecated
     def generate_string(cls, str_type, length):
         return gen_string(str_type, length)
 
     @classmethod
+    @deprecated
     def generate_alpha(cls, length=10):
         return gen_alpha(length)
 
     @classmethod
+    @deprecated
     def generate_alphanumeric(cls, length=10):
         return gen_alphanumeric(length)
 
     @classmethod
+    @deprecated
     def generate_boolean(cls):
         return gen_boolean()
 
     @classmethod
+    @deprecated
     def generate_choice(cls, choices):
         return gen_choice(choices)
 
     @classmethod
+    @deprecated
     def generate_cjk(cls, length=10):
         return gen_cjk(length)
 
     @classmethod
+    @deprecated
     def generate_date(cls, min_date=None, max_date=None):
         return gen_date(min_date, max_date)
 
     @classmethod
+    @deprecated
     def generate_datetime(cls, min_date=None, max_date=None):
         return gen_datetime(min_date, max_date)
 
     @classmethod
+    @deprecated
     def generate_email(cls, name=None, domain=None, tlds=None):
         return gen_email(name, domain, tlds)
 
     @classmethod
+    @deprecated
     def generate_integer(cls, min_value=None, max_value=None):
         return gen_integer(min_value, max_value)
 
     @classmethod
+    @deprecated
     def generate_iplum(cls, words=None, paragraphs=None):
         return gen_iplum(words, paragraphs)
 
     @classmethod
+    @deprecated
     def generate_latin1(cls, length=10):
         return gen_latin1(length)
 
     @classmethod
+    @deprecated
     def generate_negative_integer(cls):
         return gen_negative_integer()
 
     @classmethod
+    @deprecated
     def generate_ipaddr(cls, ip3=False, ipv6=False):
         return gen_ipaddr(ip3, ipv6)
 
     @classmethod
+    @deprecated
     def generate_mac(cls, delimiter=":"):
         return gen_mac(delimiter)
 
     @classmethod
+    @deprecated
     def generate_numeric_string(cls, length=10):
         return gen_numeric_string(length)
 
     @classmethod
+    @deprecated
     def generate_positive_integer(cls):
         return gen_integer()
 
     @classmethod
+    @deprecated
     def generate_time(cls):
         return gen_time()
 
     @classmethod
+    @deprecated
     def generate_url(cls, scheme=None, subdomain=None, tlds=None):
         return gen_url(scheme, subdomain, tlds)
 
     @classmethod
+    @deprecated
     def generate_utf8(cls, length=10):
         return gen_utf8(length)
 
     @classmethod
+    @deprecated
     def generate_uuid(cls):
         return gen_uuid()
 
     @classmethod
+    @deprecated
     def generate_html(cls, length=10):
         return gen_html(length)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -3,7 +3,42 @@ from fauxfactory import codify, FauxFactory
 from functools import partial
 from unittest import TestCase
 import datetime
+import warnings
 # (too-many-public-methods) pylint:disable=R0904
+
+GENERATORS = (
+    partial(codify, 'make-me-unicode'),
+    partial(FauxFactory.generate_string, 'alpha', 3),
+    partial(FauxFactory.generate_alpha, 3),
+    partial(FauxFactory.generate_alphanumeric, 3),
+    FauxFactory.generate_boolean,
+    partial(FauxFactory.generate_choice, (1, 2)),
+    partial(FauxFactory.generate_cjk, 3),
+    partial(
+        FauxFactory.generate_date,
+        datetime.date.today() - datetime.timedelta(1),
+        datetime.date.today()
+    ),
+    partial(
+        FauxFactory.generate_datetime,
+        datetime.datetime.now() - datetime.timedelta(1),
+        datetime.datetime.today()
+    ),
+    partial(FauxFactory.generate_email, 'Alice', 'example', 'com'),
+    partial(FauxFactory.generate_integer, 1, 10),
+    partial(FauxFactory.generate_iplum, 1, 1),
+    partial(FauxFactory.generate_latin1, 3),
+    FauxFactory.generate_negative_integer,
+    partial(FauxFactory.generate_ipaddr, True, True),
+    partial(FauxFactory.generate_mac, '-'),
+    partial(FauxFactory.generate_numeric_string, 3),
+    FauxFactory.generate_positive_integer,
+    FauxFactory.generate_time,
+    partial(FauxFactory.generate_url, 'ftp', 'example', 'com'),
+    partial(FauxFactory.generate_utf8, 3),
+    FauxFactory.generate_uuid,
+    partial(FauxFactory.generate_html, 3),
+)
 
 
 class FauxFactoryTestCase(TestCase):
@@ -22,38 +57,16 @@ class FauxFactoryTestCase(TestCase):
         * returns an "interesting" value.
 
         """
-        generators = (
-            partial(codify, 'make-me-unicode'),
-            partial(FauxFactory.generate_string, 'alpha', 3),
-            partial(FauxFactory.generate_alpha, 3),
-            partial(FauxFactory.generate_alphanumeric, 3),
-            FauxFactory.generate_boolean,
-            partial(FauxFactory.generate_choice, (1, 2)),
-            partial(FauxFactory.generate_cjk, 3),
-            partial(
-                FauxFactory.generate_date,
-                datetime.date.today() - datetime.timedelta(1),
-                datetime.date.today()
-            ),
-            partial(
-                FauxFactory.generate_datetime,
-                datetime.datetime.now() - datetime.timedelta(1),
-                datetime.datetime.today()
-            ),
-            partial(FauxFactory.generate_email, 'Alice', 'example', 'com'),
-            partial(FauxFactory.generate_integer, 1, 10),
-            partial(FauxFactory.generate_iplum, 1, 1),
-            partial(FauxFactory.generate_latin1, 3),
-            FauxFactory.generate_negative_integer,
-            partial(FauxFactory.generate_ipaddr, True, True),
-            partial(FauxFactory.generate_mac, '-'),
-            partial(FauxFactory.generate_numeric_string, 3),
-            FauxFactory.generate_positive_integer,
-            FauxFactory.generate_time,
-            partial(FauxFactory.generate_url, 'ftp', 'example', 'com'),
-            partial(FauxFactory.generate_utf8, 3),
-            FauxFactory.generate_uuid,
-            partial(FauxFactory.generate_html, 3),
-        )
-        for generator in generators:
+
+        for generator in GENERATORS:
             self.assertIsNotNone(generator())
+
+    def test_deprecated_warning(self):
+        """Check that ``FauxFactory`` functions show deprecation message.
+
+        """
+
+        for generator in GENERATORS:
+            with warnings.catch_warnings(record=True) as faux_warn:
+                self.assertIsNotNone(generator())
+                self.assertIn('deprecated', str(faux_warn[-1].message))


### PR DESCRIPTION
Now when someone imports `FauxFactory` and uses any of its 'older'
functions, a deprecation warning message will be displayed as shown
below:

``` python
In [1]: from fauxfactory import FauxFactory
fauxfactory/__init__.py:723: Warning: The FauxFactory class is deprecated. Please use functions from the fauxfactory module instead.
  category=Warning)

In [2]: FauxFactory.generate_alpha()
fauxfactory/__init__.py:696: Warning: Function generate_alpha is now deprecated! Please update your your code to use the gen_alpha function instead.
  warnings.warn(warn_message.format(name, new_name), category=Warning)
Out[2]: u'miRSshikjd'
```

Tests included. Closes #51.
