### PR TITLE
Make gen_netmask verify function arguments

### DIFF
--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -522,8 +522,19 @@ def gen_netmask(min_cidr=1, max_cidr=31):
     :returns: The netmask is chosen from
         :data:`fauxfactory.constants.VALID_NETMASKS` respecting the CIDR range
     :rtype: str
+    :raises: ``ValueError`` if ``min_cidr`` or ``max_cidr`` have an invalid
+        value. For example, ``max_cidr`` cannot be 33.
 
     """
+    if min_cidr < 0:
+        raise ValueError(
+            'min_cidr must be 0 or greater, but is {0}'.format(min_cidr)
+        )
+    if max_cidr >= len(VALID_NETMASKS):
+        raise ValueError(
+            'max_cidr must be less than {0}, but is {1}'
+            .format(len(VALID_NETMASKS), max_cidr)
+        )
     return VALID_NETMASKS[random.randint(min_cidr, max_cidr)]
 
 

--- a/tests/test_netmasks.py
+++ b/tests/test_netmasks.py
@@ -28,6 +28,10 @@ class NetmaskTestCase(unittest.TestCase):
         """Test gen_netmask boundary cases"""
         self.assertEqual(u'0.0.0.0', gen_netmask(0, 0))
         self.assertEqual(u'255.255.255.255', gen_netmask(32, 32))
+        with self.assertRaises(ValueError):
+            gen_netmask(-1, 16)
+        with self.assertRaises(ValueError):
+            gen_netmask(16, 33)
 
     def test_valid_netmasks(self):
         """Test if VALID_NETMASKS constant have valid netmask values"""


### PR DESCRIPTION
Make `gen_netmask` raise a `ValueError` if `min_cidr` is less than 0 or
`max_cidr` is greater than 32. Add tests for this boundary checking code.

```
$ make test
python -m unittest discover --start-directory tests --top-level-directory .
.................................................................................................................................................................
----------------------------------------------------------------------
Ran 161 tests in 1.508s

OK
```

Fix #57.
