### PR TITLE
gen_integer() change

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,5 +17,6 @@ Contributors
 - Jacob Callahan `@JacobCallahan <https://github.com/JacobCallahan>`_
 - Jefferson Fausto Vaz `@faustovaz <https://github.com/faustovaz/>`_
 - Jeremy Audet `@Ichimonji10 <https://github.com/Ichimonji10/>`_
+- Jonathan Edwards `@apense <https://github.com/apense/>`_
 - Kedar Bidarkar  `@kbidarkar <https://github.com/kbidarkar/>`_
 - Sachin Ghai `@sghai <https://github.com/sghai/>`_

--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -342,10 +342,15 @@ def gen_integer(min_value=None, max_value=None):
     if max_value is None:
         max_value = _max_value
 
+    if sys.version_info.major < 3:
+        integer_types = (int, long,)
+    else:
+        integer_types = (int,)
+
     # Perform some validations
-    if not isinstance(min_value, int) or min_value < _min_value:
+    if not isinstance(min_value, integer_types) or min_value < _min_value:
         raise ValueError("\'%s\' is not a valid minimum." % min_value)
-    if not isinstance(max_value, int) or max_value > _max_value:
+    if not isinstance(max_value, integer_types) or max_value > _max_value:
         raise ValueError("\'%s\' is not a valid maximum." % max_value)
 
     value = random.randint(min_value, max_value)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -22,9 +22,13 @@ class TestNumbers(unittest.TestCase):
         @Assert: A random integer is created
         """
 
+        if sys.version < '3':
+            integer_types = (int, long,)
+        else:
+            integer_types = (int,)
         result = gen_integer()
         self.assertTrue(
-            isinstance(result, int), "A valid integer was not generated.")
+            isinstance(result, integer_types), "A valid integer was not generated.")
 
     def test_gen_integer_2(self):
         """


### PR DESCRIPTION
Using Win64 Python2.7, sys.maxsize returns a long and the `isinstance(maxsize, int)` test fails. I updated this to a tuple to consider the differences with Python3 (which doesn't really use `long()`) by adding an integer types tuple `(int, long,)` depending on the platform.
