### PR TITLE
Use setuptools for packaging, lint `setup.py`

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,8 +20,8 @@ docs-html:
 
 lint:
 	flake8 .
-	pylint --reports=n --disable=I --ignore-imports=y fauxfactory docs/conf.py
-# pylint should also lint setup.py and the tests/ directory.
+	pylint --reports=n --disable=I --ignore-imports=y fauxfactory docs/conf.py setup.py
+# pylint should also lint the tests/ directory.
 
 test:
 	python $(unittest-args)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 """A setuptools-based script for installing FauxFactory."""
-from distutils.core import setup
+# setuptools is preferred over distutils. See:
+# https://packaging.python.org/en/latest/current.html#packaging-tool-recommendations
+from setuptools import find_packages, setup
 import os
 
 
@@ -20,7 +22,7 @@ setup(
     author='Og Maciel',
     author_email='omaciel@ogmaciel.com',
     url='https://github.com/omaciel/fauxfactory',
-    packages=['fauxfactory'],
+    packages=find_packages(),
     keywords='python automation data',
     license='Apache 2.0',
     classifiers=[


### PR DESCRIPTION
setuptools is preferred over distutils when packaging projects. See:
https://packaging.python.org/en/latest/current.html#packaging-tool-recommendations

`setup.py` is now flake8 and pylint-compliant. Add it to the `lint` make target.