### PR TITLE
Drop unnecessary lines from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,3 @@ include AUTHORS.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
-include makefile
-include fauxfactory/*.py
-include docs/*
-include tests/*.py


### PR DESCRIPTION
Drop several redundant lines from MANIFEST.in. The `sdist` command automatically
generates a MANIFEST file using built-in rules, and the MANIFEST.in file only
needs to specify files that are not covered by the built-in rules. See:
https://docs.python.org/3.4/distutils/sourcedist.html#specifying-the-files-to-distribute

Drop the `include makefile` line from MANIFEST.in. There is no apparent use for
it. Drop the `docs` directory for the same reason.