### PR TITLE
Add python-2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
-python:
-  - 2.7
-  - 3.3
-  - 3.4
+# Should be identical to envlist in tox.ini. See:
+# http://tox.readthedocs.org/en/latest/config.html#confval-envlist=CSV
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
 install:
-  pip install -r requirements-optional.txt
+  pip install tox
 script:
-  make test-all
+  tox
 after_success:
   coveralls
 notifications:

--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -57,7 +57,7 @@ def _make_unicode(data):
         cast is necessary, a copy of ``data`` is returned.
 
     """
-    if sys.version_info.major == 2:
+    if sys.version_info[0] == 2:
         return unicode(data)  # flake8:noqa pylint:disable=undefined-variable
     return data
 
@@ -79,7 +79,7 @@ def _unicode_letters_generator():
     :return: a generator which will generates all unicode letters available
 
     """
-    if sys.version_info.major == 2:
+    if sys.version_info[0] == 2:
         chr_function = unichr  # pylint:disable=undefined-variable
         range_function = xrange  # pylint:disable=undefined-variable
     else:
@@ -238,7 +238,7 @@ def gen_cjk(length=10):
     # valid range of CJK codepoints is 0x4E00 - 0x9FCC, inclusive. Python 2
     # and 3 support the `unichr` and `chr` functions, respectively.
     codepoints = [random.randint(0x4E00, 0x9FCC) for _ in range(length)]
-    if sys.version_info.major == 2:
+    if sys.version_info[0] == 2:
         # pylint:disable=undefined-variable
         output = u''.join(unichr(codepoint) for codepoint in codepoints)
     else:
@@ -391,7 +391,7 @@ def gen_integer(min_value=None, max_value=None):
     if max_value is None:
         max_value = _max_value
 
-    if sys.version_info.major < 3:
+    if sys.version_info[0] < 3:
         integer_types = (int, long,)  # pylint:disable=undefined-variable
     else:
         integer_types = (int,)
@@ -494,7 +494,7 @@ def gen_latin1(length=10):
     for i in range(int(range2[0], 16), int(range2[1], 16)):
         output_array.append(i)
 
-    if sys.version_info.major == 2:
+    if sys.version_info[0] == 2:
         output_string = u''.join(
             # pylint:disable=E0602
             unichr(random.choice(output_array)) for _ in range(length)
@@ -532,7 +532,7 @@ def gen_ipaddr(ip3=False, ipv6=False):
 
     if ipv6:
         # StackOverflow.com questions: generate-random-ipv6-address
-        ipaddr = u':'.join('{:x}'.format(
+        ipaddr = u':'.join('{0:x}'.format(
             random.randint(0, 2**16 - 1)
         ) for i in range(8))
     else:

--- a/makefile
+++ b/makefile
@@ -1,4 +1,6 @@
-unittest-args = -m unittest discover --start-directory tests --top-level-directory .
+UNITTEST_CMD ?= unit2
+UNITTEST_MOD ?= unittest
+UNITTEST_ARGS ?= discover --start-directory tests --top-level-directory .
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
@@ -24,9 +26,9 @@ lint:
 # pylint should also lint the tests/ directory.
 
 test:
-	python $(unittest-args)
+	$(UNITTEST_CMD) $(UNITTEST_ARGS)
 
 test-all: lint docs-doctest
-	coverage run $(unittest-args)
+	coverage run -m $(UNITTEST_MOD) $(UNITTEST_ARGS)
 
 .PHONY: help docs-clean docs-doctest docs-html lint test test-all

--- a/requirements-optional-26.txt
+++ b/requirements-optional-26.txt
@@ -1,0 +1,10 @@
+# https://bitbucket.org/logilab/astroid/issue/76/python26-compatibility
+astroid<1.3
+coverage
+coveralls
+flake8
+# https://bitbucket.org/logilab/pylint/issue/390/py26-compatiblity-broken
+pylint<1.4
+Sphinx
+unittest2
+discover

--- a/tests/test_booleans.py
+++ b/tests/test_booleans.py
@@ -3,8 +3,12 @@
 """Tests for all boolean generators."""
 
 from fauxfactory import gen_boolean
+from sys import version_info
 
-import unittest
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestBooleans(unittest.TestCase):

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -2,10 +2,14 @@
 
 """Tests for all choice generators."""
 
-from fauxfactory import gen_choice
-
 import string
-import unittest
+from fauxfactory import gen_choice
+from sys import version_info
+
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestChoices(unittest.TestCase):

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,10 +1,17 @@
 """Tests to help ensure that FauxFactory remains backward compatible."""
 from fauxfactory import codify, FauxFactory
 from functools import partial
-from unittest import TestCase
+from sys import version_info
+
 import datetime
 import warnings
 # (too-many-public-methods) pylint:disable=R0904
+
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
 
 GENERATORS = (
     partial(codify, 'make-me-unicode'),
@@ -41,7 +48,7 @@ GENERATORS = (
 )
 
 
-class FauxFactoryTestCase(TestCase):
+class FauxFactoryTestCase(unittest.TestCase):
     """Call methods on class ``FauxFactory``."""
     def test_not_none(self):
         """Call every method on ``FauxFactory`` and provide arguments.

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -2,11 +2,15 @@
 
 """Tests for date generator."""
 
+import datetime
 from fauxfactory import gen_date
 from fauxfactory.constants import MAX_YEARS, MIN_YEARS
+from sys import version_info
 
-import datetime
-import unittest
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestDates(unittest.TestCase):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -2,11 +2,15 @@
 
 """Tests for datetime generator."""
 
+import datetime
 from fauxfactory import gen_date, gen_datetime
 from fauxfactory.constants import MAX_YEARS, MIN_YEARS
+from sys import version_info
 
-import datetime
-import unittest
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestDates(unittest.TestCase):

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -2,10 +2,14 @@
 
 """Tests for Email generator."""
 
-from fauxfactory import gen_email
-
 import re
-import unittest
+from fauxfactory import gen_email
+from sys import version_info
+
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 REGEX = r"^[a-zA-Z][a-zA-Z-.]*[^.-]@\w*\.[a-zA-Z]{2,3}"
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -2,11 +2,15 @@
 
 """Tests for HTML generator."""
 
+from sys import version_info
 from fauxfactory import gen_html, gen_integer
 import re
-import sys
-import unittest
 # (too-many-public-methods) pylint:disable=R0904
+
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestHTML(unittest.TestCase):
@@ -52,7 +56,7 @@ class TestHTML(unittest.TestCase):
         """
 
         result = gen_html()
-        if sys.version_info[0] is 2:
+        if version_info[0] is 2:
             # (undefined-variable) pylint:disable=E0602
             self.assertIsInstance(result, unicode)  # flake8:noqa
         else:

--- a/tests/test_ipaddress.py
+++ b/tests/test_ipaddress.py
@@ -2,9 +2,13 @@
 
 """Tests for ipaddr generator."""
 
+from sys import version_info
 from fauxfactory import gen_ipaddr
 
-import unittest
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestIpaddr(unittest.TestCase):

--- a/tests/test_lorem_ipsum.py
+++ b/tests/test_lorem_ipsum.py
@@ -2,11 +2,15 @@
 
 """Tests for Lorem Ipsum generator."""
 
+import random
+from sys import version_info
 from fauxfactory import gen_iplum
 from fauxfactory.constants import LOREM_IPSUM_TEXT
 
-import random
-import unittest
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestLoremIpsum(unittest.TestCase):

--- a/tests/test_macs.py
+++ b/tests/test_macs.py
@@ -2,12 +2,17 @@
 
 """Tests for MAC generator."""
 
-from fauxfactory import gen_mac
-
 import random
 import re
 import string
-import unittest
+from sys import version_info
+from fauxfactory import gen_mac
+
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
 
 mac = re.compile("[0-9a-f]{2}([-:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$")
 

--- a/tests/test_netmasks.py
+++ b/tests/test_netmasks.py
@@ -2,9 +2,13 @@
 """Tests for the netmask generator"""
 
 import re
-import unittest
-
+from sys import version_info
 from fauxfactory import gen_netmask, VALID_NETMASKS
+
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 NETMASK_REGEX = re.compile(

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -9,7 +9,10 @@ from fauxfactory import (
 )
 
 import sys
-import unittest
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestNumbers(unittest.TestCase):

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -4,8 +4,6 @@
 
 import random
 import unicodedata
-import unittest
-
 from fauxfactory import (
     gen_alpha,
     gen_alphanumeric,
@@ -19,6 +17,11 @@ from fauxfactory import (
     _unicode_letters_generator,
 )
 from sys import version_info
+
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestStrings(unittest.TestCase):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -2,10 +2,14 @@
 
 """Tests for Time generator."""
 
+import datetime
+from sys import version_info
 from fauxfactory import gen_time
 
-import unittest
-import datetime
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestTime(unittest.TestCase):

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -2,8 +2,7 @@
 
 """Tests for URL generator."""
 
-import unittest
-
+from sys import version_info
 from fauxfactory import (
     gen_alpha,
     gen_alphanumeric,
@@ -12,6 +11,11 @@ from fauxfactory import (
     gen_url,
 )
 from fauxfactory.constants import SCHEMES
+
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestURLs(unittest.TestCase):

--- a/tests/test_uuids.py
+++ b/tests/test_uuids.py
@@ -2,9 +2,13 @@
 
 """Tests for UUID generator."""
 
+from sys import version_info
 from fauxfactory import gen_uuid
 
-import unittest
+if version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestUUID(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[pytest]
+minversion = 2.6
+
+[tox]
+envlist = py26,py27,py33,py34
+
+[testenv]
+whitelist_externals = make
+deps = -r{toxinidir}/requirements-optional.txt
+commands = make test-all
+
+[testenv:py26]
+setenv =
+    UNITTEST_MOD = unittest2
+whitelist_externals = make
+deps = -r{toxinidir}/requirements-optional-26.txt
+commands = make test-all


### PR DESCRIPTION
Support python-2.6
    
* Adds a tox.ini to facilitate testing supported py_versions
* Add a requirements-optional-26.txt file
* Update fauxfactory/__init__.py to support 2.6 syntax
* updates tests/test_*.py to conditionally import unittest2
* Add 2.6 to .travis.yml
