### PR TITLE
Enable passing a prefix for IP addresses

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,3 +21,4 @@ Contributors
 - Jonathan Edwards `@apense <https://github.com/apense/>`_
 - Kedar Bidarkar  `@kbidarkar <https://github.com/kbidarkar/>`_
 - Sachin Ghai `@sghai <https://github.com/sghai/>`_
+- Milan Falešník `@mfalesni <https://github.com/mfalesni/>`_

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,14 @@
 # setuptools is preferred over distutils. See:
 # https://packaging.python.org/en/latest/current.html#packaging-tool-recommendations
 from setuptools import find_packages, setup
+import codecs
 import os
 
 
 def read(*paths):
     """Build a file path from *paths* and return the contents."""
-    with open(os.path.join(*paths), 'r') as handle:
+    filename = os.path.join(*paths)
+    with codecs.open(filename, mode='r', encoding="utf-8") as handle:
         return handle.read()
 
 LONG_DESCRIPTION = (read('README.rst') + '\n\n' +

--- a/tests/test_ipaddress.py
+++ b/tests/test_ipaddress.py
@@ -63,6 +63,99 @@ class TestIpaddr(unittest.TestCase):
             len(result.split(".")) == 4,
             "Did not generate a 4-group IPv4 addrss")
 
+    def test_gen_ipv4_5(self):
+        """
+        @Test: Generate a 4 group IPv4 address with good prefix
+        @Feature: IPAddr Generator
+        @Assert: A 4-group IPv4 address is generated
+        """
+
+        result = gen_ipaddr(ip3=False, ipv6=False, prefix=[10])
+        self.assertTrue(
+            len(result.split(".")) == 4,
+            "Did not generate a 4-group IPv4 addrss")
+        self.assertTrue(result.startswith("10."))
+
+    def test_gen_ipv4_6(self):
+        """
+        @Test: Generate a 4 group IPv4 address with good prefix
+        @Feature: IPAddr Generator
+        @Assert: A 4-group IPv4 address is generated
+        """
+
+        result = gen_ipaddr(ip3=False, ipv6=False, prefix=[10, 10])
+        self.assertTrue(
+            len(result.split(".")) == 4,
+            "Did not generate a 4-group IPv4 addrss")
+        self.assertTrue(result.startswith("10.10."))
+
+    def test_gen_ipv4_7(self):
+        """
+        @Test: Generate a 4 group IPv4 address with good prefix
+        @Feature: IPAddr Generator
+        @Assert: A 4-group IPv4 address is generated
+        """
+
+        result = gen_ipaddr(ip3=False, ipv6=False, prefix=[10, 10, 10])
+        self.assertTrue(
+            len(result.split(".")) == 4,
+            "Did not generate a 4-group IPv4 addrss")
+        self.assertTrue(result.startswith("10.10.10."))
+
+    def test_gen_ipv4_8(self):
+        """
+        @Test: Generate a 4 group IPv4 address with prefix disabling randomness
+        @Feature: IPAddr Generator
+        @Assert: An exception is raised
+        """
+
+        with self.assertRaises(ValueError):
+            gen_ipaddr(ip3=False, ipv6=False, prefix=[10, 10, 10, 10])
+
+    def test_gen_ipv4_9(self):
+        """
+        @Test: Generate a 4 group IPv4 address with prefix too long
+        @Feature: IPAddr Generator
+        @Assert: An exception is raised
+        """
+
+        with self.assertRaises(ValueError):
+            gen_ipaddr(ip3=False, ipv6=False, prefix=[10, 10, 10, 10, 10])
+
+    def test_gen_ipv4_10(self):
+        """
+        @Test: Generate a 3 group IPv4 address with good prefix
+        @Feature: IPAddr Generator
+        @Assert: A 3-group IPv4 address is generated
+        """
+
+        result = gen_ipaddr(ip3=True, ipv6=False, prefix=[10, 10])
+        self.assertTrue(
+            len(result.split(".")) == 4,
+            "Did not generate a 4-group IPv4 addrss")
+        self.assertTrue(result.startswith("10.10."))
+        self.assertTrue(result.endswith(".0"))
+
+    def test_gen_ipv4_11(self):
+        """
+        @Test: Generate a 3 group IPv4 address with prefix disabling randomness
+        @Feature: IPAddr Generator
+        @Assert: An exception is raised
+        """
+
+        with self.assertRaises(ValueError):
+            gen_ipaddr(ip3=True, ipv6=False, prefix=[10, 10, 10])
+
+    def test_gen_ipv4_12(self):
+        """
+        @Test: Generate a 3 group IPv4 address with prefix too long
+        @Feature: IPAddr Generator
+        @Assert: An exception is raised
+        """
+
+        with self.assertRaises(ValueError):
+            gen_ipaddr(ip3=True, ipv6=False, prefix=[10, 10, 10, 10])
+
     def test_gen_ipv6_1(self):
         """
         @Test: Generate a IPv6 address
@@ -86,3 +179,52 @@ class TestIpaddr(unittest.TestCase):
         self.assertTrue(
             len(result.split(":")) == 8,
             "Did not generate a IPv6 addrss")
+
+    def test_gen_ipv6_3(self):
+        """
+        @Test: Generate a IPv6 address with custom prefix
+        @Feature: IPAddr Generator
+        @Assert: A IPv6 address is generated
+        """
+
+        result = gen_ipaddr(ipv6=True, prefix=["e2d3"])
+        self.assertTrue(
+            len(result.split(":")) == 8,
+            "Did not generate a IPv6 addrss")
+        self.assertTrue(result.startswith("e2d3:"))
+
+    def test_gen_ipv6_4(self):
+        """
+        @Test: Generate a IPv6 address with custom (very long) prefix
+        @Feature: IPAddr Generator
+        @Assert: A IPv6 address is generated
+        """
+
+        prefix = 7 * ["e2d3"]
+        result = gen_ipaddr(ipv6=True, prefix=prefix)
+        self.assertTrue(
+            len(result.split(":")) == 8,
+            "Did not generate a IPv6 addrss")
+        self.assertTrue(result.startswith(":".join(prefix)))
+
+    def test_gen_ipv6_5(self):
+        """
+        @Test: Generate a IPv6 address with too long prefix
+        @Feature: IPAddr Generator
+        @Assert: ValueError raised
+        """
+
+        prefix = 8 * ["e2d3"]
+        with self.assertRaises(ValueError):
+            gen_ipaddr(ipv6=True, prefix=prefix)
+
+    def test_gen_ipv6_6(self):
+        """
+        @Test: Generate a IPv6 address with even longer prefix
+        @Feature: IPAddr Generator
+        @Assert: ValueError raised
+        """
+
+        prefix = 9 * ["e2d3"]
+        with self.assertRaises(ValueError):
+            gen_ipaddr(ipv6=True, prefix=prefix)


### PR DESCRIPTION
I hope tests say all, intended to replace https://github.com/RedHatQE/cfme_tests/blob/master/utils/randomness.py#L5


*btw. what's wrong on map(str, prefix_ipv4 or []) ? Shorter than the list comprehension* :smile: 