### PR TITLE
Added a method gen_vm_mac() to generate valid mac for QEMU/KVM virtual machines

### DIFF
--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -596,6 +596,28 @@ def gen_mac(delimiter=":"):
     return _make_unicode(mac)
 
 
+def gen_vm_mac(delimiter=":"):
+    """Generates a random MAC address for QEMU/KVM VM's.
+
+    :param str delimeter: Valid MAC delimeter (e.g ':', '-').
+    :returns: A random MAC address.
+    :rtype: str
+
+    """
+
+    if delimiter not in [":", "-"]:
+        raise ValueError("Delimiter is not a valid option: %s" % delimiter)
+
+    chars = ['a', 'b', 'c', 'd', 'e', 'f',
+             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+
+    mac = delimiter.join(
+        chars[random.randrange(0, len(chars), 1)]+chars[random.randrange(
+            0, len(chars), 1)] for x in range(3))
+    vm_mac = '54:52:00:{0}'.format(mac)
+
+    return _make_unicode(vm_mac)
+
 def gen_netmask(min_cidr=1, max_cidr=31):
     """Generates a random valid netmask.
 


### PR DESCRIPTION
For discovery feature, I need a valid mac that I can use for VM provisioning. However the current gen_mac() doesn't generate a valid mac for VM's on QEMU/KVM.  The mac address must start  with sequence: `54:52:00` otherwise VM  creation fails with error:

`ERROR    XML error: expected unicast mac address, found multicast '63:8e:b3:53:77:b1'`

So I added a new method to generate vm mac. `gen_vm_mac()`. We can update existing one too if that's the best option ?