### PR TITLE
Improve MAC address generation

### DIFF
--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -546,24 +546,51 @@ def gen_ipaddr(ip3=False, ipv6=False):
     return _make_unicode(ipaddr)
 
 
-def gen_mac(delimiter=":"):
+def gen_mac(delimiter=':', multicast=None, locally=None):
     """Generates a random MAC address.
 
+    For more information about how unicast or multicast and globally unique and
+    locally administered MAC addresses are generated check this link
+    https://en.wikipedia.org/wiki/MAC_address.
+
     :param str delimeter: Valid MAC delimeter (e.g ':', '-').
+    :param bool multicast: Indicates if the generated MAC address should be
+        unicast or multicast. If no value is provided a random one will be
+        chosen.
+    :param bool locally: Indicates if the generated MAC address should be
+        globally unique or locally administered. If no value is provided a
+        random one will be chosen.
     :returns: A random MAC address.
     :rtype: str
 
     """
 
-    if delimiter not in [":", "-"]:
-        raise ValueError("Delimiter is not a valid option: %s" % delimiter)
+    if delimiter not in [':', '-']:
+        raise ValueError('Delimiter is not a valid option: %s' % delimiter)
+    if multicast is None:
+        multicast = bool(random.randint(0, 1))
+    if locally is None:
+        locally = bool(random.randint(0, 1))
 
-    chars = ['a', 'b', 'c', 'd', 'e', 'f',
-             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+    first_octet = random.randint(0, 255)
+    if multicast:
+        # Ensure that the first least significant bit is 1
+        first_octet |= 0b00000001
+    else:
+        # Ensure that the first least significant bit is 0
+        first_octet &= 0b11111110
+    if locally:
+        # Ensure that the second least significant bit is 1
+        first_octet |= 0b00000010
+    else:
+        # Ensure that the second least significant bit is 0
+        first_octet &= 0b11111101
 
-    mac = delimiter.join(
-        chars[random.randrange(0, len(chars), 1)]+chars[random.randrange(
-            0, len(chars), 1)] for x in range(6))
+    octets = [first_octet]
+    octets.extend([
+        random.randint(0, 255) for _ in range(5)
+    ])
+    mac = delimiter.join(['{0:02x}'.format(octet) for octet in octets])
 
     return _make_unicode(mac)
 

--- a/tests/test_macs.py
+++ b/tests/test_macs.py
@@ -105,3 +105,47 @@ class TestMacs(unittest.TestCase):
         with self.assertRaises(ValueError):
             gen_mac(
                 delimiter=random.choice(string.ascii_letters))
+
+    def test_gen_mac_unicast_globally_unique(self):
+        """
+        @Test: Generate a unicast and globally unique MAC address
+        @Feature: MAC Generator
+        @Assert: A unicast and globally unique MAC address is generated
+        """
+        mac = gen_mac(multicast=False, locally=False)
+        first_octect = int(mac.split(':', 1)[0], 16)
+        mask = 0b00000011
+        self.assertEqual(first_octect & mask, 0)
+
+    def test_gen_mac_multicast_globally_unique(self):
+        """
+        @Test: Generate a multicast and globally unique MAC address
+        @Feature: MAC Generator
+        @Assert: A multicast and globally unique MAC address is generated
+        """
+        mac = gen_mac(multicast=True, locally=False)
+        first_octect = int(mac.split(':', 1)[0], 16)
+        mask = 0b00000011
+        self.assertEqual(first_octect & mask, 1)
+
+    def test_gen_mac_unicast_locally_administered(self):
+        """
+        @Test: Generate a unicast and locally administered MAC address
+        @Feature: MAC Generator
+        @Assert: A unicast and locally administered MAC address is generated
+        """
+        mac = gen_mac(multicast=False, locally=True)
+        first_octect = int(mac.split(':', 1)[0], 16)
+        mask = 0b00000011
+        self.assertEqual(first_octect & mask, 2)
+
+    def test_gen_mac_multicast_locally_administered(self):
+        """
+        @Test: Generate a multicast and locally administered MAC address
+        @Feature: MAC Generator
+        @Assert: A multicast and locally administered MAC address is generated
+        """
+        mac = gen_mac(multicast=True, locally=True)
+        first_octect = int(mac.split(':', 1)[0], 16)
+        mask = 0b00000011
+        self.assertEqual(first_octect & mask, 3)


### PR DESCRIPTION
Provide arguments to control how MAC addresses are generated. Now it is
possible to specify if a unicast or multicast and globally unique or
locally administered MAC address is generated.

@omaciel  thanks for the amazing pair programming session, specially for the English writing tips.