### PR TITLE
don't install tests into the binary distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author='Og Maciel',
     author_email='omaciel@ogmaciel.com',
     url='https://github.com/omaciel/fauxfactory',
-    packages=find_packages(),
+    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     keywords='python automation data',
     license='Apache 2.0',
     classifiers=[


### PR DESCRIPTION
this tries to install a "tests" python package, which we don't own.
at the same time, also exclude docs and contrib as done in the PyPA
sample project [1]

[1] https://github.com/pypa/sampleproject/blob/master/setup.py