### PR TITLE
Make `gen_utf8` return optionally only BMP characters.

### DIFF
--- a/fauxfactory/factories/strings.py
+++ b/fauxfactory/factories/strings.py
@@ -11,9 +11,6 @@ from fauxfactory.helpers import (
     )
 
 
-UNICODE_LETTERS = [c for c in unicode_letters_generator()]
-
-
 def gen_string(str_type, length=None, validator=None, default=None, tries=10):
     """A simple wrapper that calls other string generation methods.
 
@@ -286,18 +283,21 @@ def gen_numeric_string(length=10):
 
 @check_len
 @check_validation
-def gen_utf8(length=10):
+def gen_utf8(length=10, smp=True):
     """Return a random string made up of UTF-8 letters characters.
 
     Follows `RFC 3629`_.
 
     :param int length: Length for random data.
+    :param bool smp: Include Supplementary Multilingual Plane (SMP)
+        characters
     :returns: A random string made up of ``UTF-8`` letters characters.
     :rtype: str
 
     .. _`RFC 3629`: http://www.rfc-editor.org/rfc/rfc3629.txt
 
     """
+    UNICODE_LETTERS = [c for c in unicode_letters_generator(smp)]
     random.seed()
     return ''.join([random.choice(UNICODE_LETTERS) for _ in range(length)])
 

--- a/fauxfactory/helpers.py
+++ b/fauxfactory/helpers.py
@@ -1,10 +1,16 @@
 """Collection of helper methods and functions."""
 import re
-import sys
 import unicodedata
 
+from collections import namedtuple
 from functools import wraps
 from fauxfactory.constants import VALID_DIGITS
+
+
+UnicodePlane = namedtuple('UnicodePlane', ['min', 'max'])
+
+BMP = UnicodePlane(int('0x0000', 16), int('0xffff', 16))
+SMP = UnicodePlane(int('0x10000', 16), int('0x1ffff', 16))
 
 
 def base_repr(number, base):
@@ -125,19 +131,15 @@ def is_positive_int(length):
         raise ValueError('{0} is an invalid \'length\'.'.format(length))
 
 
-def unicode_letters_generator():
+def unicode_letters_generator(smp=True):
     """Generate unicode characters in the letters category.
 
+    :param bool smp: Include Supplementary Multilingual Plane (SMP)
+        characters
     :return: a generator which will generates all unicode letters available
 
     """
-    chr_function = chr
-    range_function = range
-    # Use sys.maxunicode instead of 0x10FFFF to avoid the exception below, in a
-    # narrow Python build (before Python 3.3)
-    # ValueError: unichr() arg not in range(0x10000) (narrow Python build)
-    # For more information, read PEP 261.
-    for i in range_function(sys.maxunicode):
-        char = chr_function(i)
+    for i in range(BMP.min, SMP.max if smp else BMP.max):
+        char = chr(i)
         if unicodedata.category(char).startswith('L'):
             yield char

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -16,7 +16,7 @@ from fauxfactory import (
     gen_utf8,
     gen_special,
 )
-from fauxfactory.helpers import unicode_letters_generator
+from fauxfactory.helpers import unicode_letters_generator, BMP
 
 
 GENERATORS = [
@@ -130,6 +130,12 @@ def test_chars_in_letters_category():
     # http://www.unicode.org/reports/tr44/tr44-4.html
     for char in unicode_letters_generator():
         assert unicodedata.category(char) in ('Lu', 'Ll', 'Lt', 'Lm', 'Lo')
+
+
+def test_bmp_chars_only():
+    """Unicode letters generator generates only BMP unicode letters."""
+    for char in gen_utf8(length=50, smp=False):
+        assert ord(char) <= BMP.max
 
 
 def test_invalid_string_type():


### PR DESCRIPTION
The `gen_utf8` string generator now accepts an optional `smp`
boolean argument which would limit the characters generated to
include Supplementary Multilingual Plane (SMP) characters (default)
in addition to Basic Multilingual Plane (BMP) characters.

This will help with UI automation on Google Chrome since it cannot
properly render SMP characters.