### PR TITLE
Fix: WARNING: py:class reference target not found

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,3 +25,4 @@ Contributors
 - Renzo Nuccitelli `@renzon <https://github.com/renzon>`_
 - Sachin Ghai `@sghai <https://github.com/sghai/>`_
 - Milan Falešník `@mfalesni <https://github.com/mfalesni/>`_
+- Nikhil Dhandre `@digitronik <https://github.com/digitronik/>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,12 +116,12 @@ nitpicky = True
 # A list of (type, target) tuples (by default empty) that should be ignored
 # when generating warnings in “nitpicky mode”.
 nitpick_ignore = [
-    ('py:obj', 'bool'),
-    ('py:obj', 'dict'),
-    ('py:obj', 'int'),
-    ('py:obj', 'list'),
-    ('py:obj', 'str'),
-    ('py:obj', 'tuple'),
+    ('py:class', 'bool'),
+    ('py:class', 'dict'),
+    ('py:class', 'int'),
+    ('py:class', 'list'),
+    ('py:class', 'str'),
+    ('py:class', 'tuple'),
 ]
 
 

--- a/fauxfactory/factories/strings.py
+++ b/fauxfactory/factories/strings.py
@@ -73,7 +73,7 @@ def gen_alpha(length=10, start=None, separator=''):
 
     :param int length: Length for random data.
     :param str start: Random data start with.
-    :param char separator: Separator for start and random data.
+    :param str separator: Separator character for start and random data.
     :returns: A random string made up of alpha characters.
     :rtype: str
 
@@ -96,7 +96,7 @@ def gen_alphanumeric(length=10, start=None, separator=''):
 
     :param int length: Length for random data.
     :param str start: Random data start with.
-    :param char separator: Separator for start and random data.
+    :param str separator: Separator character for start and random data.
     :returns: A random string made up of alpha and numeric characters.
     :rtype: str
 
@@ -122,7 +122,7 @@ def gen_cjk(length=10, start=None, separator=''):
 
     :param int length: Length for random data.
     :param str start: Random data start with.
-    :param char separator: Separator for start and random data.
+    :param str separator: Separator character for start and random data.
     :returns: A random string made up of CJK characters.
     :rtype: str
 
@@ -147,7 +147,7 @@ def gen_cyrillic(length=10, start=None, separator=''):
 
     :param int length: Length for random data.
     :param str start: Random data start with.
-    :param char separator: Separator for start and random data.
+    :param str separator: Separator character for start and random data.
     :returns: A random string made up of Cyrillic characters.
     :rtype: str
 
@@ -267,7 +267,7 @@ def gen_latin1(length=10, start=None, separator=''):
 
     :param int length: Length for random data.
     :param str start: Random data start with.
-    :param char separator: Separator for start and random data.
+    :param str separator: Separator character for start and random data.
     :returns: A random string made up of ``Latin1`` characters.
     :rtype: str
 
@@ -303,7 +303,7 @@ def gen_numeric_string(length=10, start=None, separator=''):
 
     :param int length: Length for random data.
     :param str start: Random data start with.
-    :param char separator: Separator for start and random data.
+    :param str separator: Separator character for start and random data.
     :returns: A random string made up of numbers.
     :rtype: str
 
@@ -328,7 +328,7 @@ def gen_utf8(length=10, smp=True, start=None, separator=''):
 
     :param int length: Length for random data.
     :param str start: Random data start with.
-    :param char separator: Separator for start and random data.
+    :param str separator: Separator character for start and random data.
     :param bool smp: Include Supplementary Multilingual Plane (SMP)
         characters
     :returns: A random string made up of ``UTF-8`` letters characters.
@@ -356,7 +356,7 @@ def gen_special(length=10, start=None, separator=''):
 
     :param int length: Length for random data.
     :param str start: Random data start with.
-    :param char separator: Separator for start and random data.
+    :param str separator: Separator character for start and random data.
     :returns: A random string made up of special characters.
     :rtype: str
     """


### PR DESCRIPTION
I don't like this way but I found this is only way to avoid this warning.

sphinx changes: https://github.com/sphinx-doc/sphinx/pull/3927/files

References:
1. There is one issue open related to python referencing of built-in types.
https://bugs.python.org/issue11975

2. In Sphinx:
https://github.com/sphinx-doc/sphinx/issues/4609#issuecomment-365301990
