### PR TITLE
Update versioning for setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,14 @@ notifications:
     email:
         on_success: always
         on_failure: always
+deploy:
+  provider: pypi
+  skip_existing: true
+  user: mshriver
+  distributions: sdist bdist_wheel
+  password:
+    secure: gy2PpSfC2ymVu85DmiOeQaEt27wG4T4NnmJgo4Ru2bzoIwFQmO3HFP0YyiMISXjccLATrZriIQTS2iX6r63rjh72alYcddDcl2tBzVOM47zFodwcgDe1s4nEUP2jNdEBmxsYHBOm0hnDTS6pVRQJGEqkRw0T2iz9eE4DgjlX6yU=
+  on:
+    tags: true
+    repo: omaciel/fauxfactory
+

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,3 +26,5 @@ Contributors
 - Sachin Ghai `@sghai <https://github.com/sghai/>`_
 - Milan Falešník `@mfalesni <https://github.com/mfalesni/>`_
 - Nikhil Dhandre `@digitronik <https://github.com/digitronik/>`_
+- Mike Shriver `@mshriver <https://github.com/mshriver/>`_
+

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,21 @@
 Release History
 ===============
 
+3.0.5 (2019-07-30)
+------------------
+
+- Update setuptools versioning, add travis deployment
+
+3.0.4 (2019-07-30)
+------------------
+
+- Resolve flake failures in travis
+
+3.0.3 (2019-07-30)
+------------------
+
+- Fixes for warnings on file resources
+
 3.0.2 (2018-04-10)
 ------------------
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -10,6 +10,7 @@ pylint
 sphinx
 
 # For `make package`
+# defined in setup.py
 wheel
 
 # For `make publish`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [wheel]
 universal = 1
+
+[options]
+setup_requires = 
+    setuptools
+    setuptools_scm
+    wheel
+

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     name='fauxfactory',
     description='Generates random data for your tests.',
     long_description=LONG_DESCRIPTION,
-    version='3.0.2',
+    use_scm_version=True,
     author='Og Maciel',
     author_email='omaciel@ogmaciel.com',
     url='https://github.com/omaciel/fauxfactory',


### PR DESCRIPTION
Static version was preventing setuptools from assigning it automatically based on the tagged version.

Setuptools will automatically detect a `3.0.5` version from tag `v3.0.5`, so the current tagging scheme can be preserved.

This change requires setuptools-scm, which I have defined in setup.cfg under `setup_requires` so that it will be included in the current Makefile scheme.

This will enable `make package` calls to install the necessary packages and build.