### PR TITLE
Update history file for v3.0.6 to trigger travis

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+3.0.6 (2019-07-30)
+------------------
+
+- Change travis deploy credentials to token
+
 3.0.5 (2019-07-30)
 ------------------
 


### PR DESCRIPTION
Travis isn't triggering on the re-tagged version, update history and generate a new tag.