### PR TITLE
Update travis to skip cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ notifications:
 deploy:
   provider: pypi
   skip_existing: true
+  skip_cleanup: true
   # mshriver owned
   user: mshriver
   distributions: sdist bdist_wheel

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+3.1.0 (2020-11-10)
+------------------
+
+- Support static analysis and type annotation
+- CI dropped Python 3.5
+
 3.0.6 (2019-07-30)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [options]
 setup_requires = 
     setuptools


### PR DESCRIPTION
Also include 3.1.0 notes in HISTORY, and remove deprecated setup.cfg section for wheel. Py2.7 is no longer supported, so a universal wheel is unnecessary.