### PR TITLE
Implement __getattr__ to help linters

### DIFF
--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -23,3 +23,9 @@ __all__ = tuple(name for name in locals() if name.startswith('gen_'))
 
 def __dir__():
     return __all__
+
+
+def __getattr__(name):
+    if name in __all__:
+        return locals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Implementing __getattr__ will help linters to figure if an attribute is
available or not.

Before:

![Screenshot from 2022-02-03 09-24-00](https://user-images.githubusercontent.com/48132/152364696-b4b3bf43-7a2c-4b48-8e04-fba490d9d073.png)

After:

![Screenshot from 2022-02-03 09-24-33](https://user-images.githubusercontent.com/48132/152364744-b9b9667a-4ea0-411b-86b5-3d45d51e8ba5.png)
