### PR TITLE
Add __getattr__ tests and fix bug

### DIFF
--- a/fauxfactory/__init__.py
+++ b/fauxfactory/__init__.py
@@ -17,8 +17,12 @@ from fauxfactory.factories.strings import *  # noqa: F401, F403
 from fauxfactory.factories.systems import *  # noqa: F401, F403
 
 
+__factories = {
+    name: obj for name, obj in locals().items() if name.startswith('gen_')
+}
+
 # Add all method names to __all__
-__all__ = tuple(name for name in locals() if name.startswith('gen_'))
+__all__ = tuple(__factories.keys())
 
 
 def __dir__():
@@ -26,6 +30,6 @@ def __dir__():
 
 
 def __getattr__(name):
-    if name in __all__:
-        return locals()[name]
+    if name in __factories:
+        return __factories[name]
     raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/tests/test_getattr.py
+++ b/tests/test_getattr.py
@@ -1,0 +1,17 @@
+"""Check of the __getattr__ of the fauxfactory package.
+
+These tests are heavily just artificial tests to get 100% coverage.
+"""
+import fauxfactory
+import pytest
+
+
+def test_fauxfactory_getattr():
+    """Check __getattr__ returns expected objects."""
+    assert fauxfactory.__getattr__('gen_integer') is fauxfactory.gen_integer
+
+
+def test_fauxfactory_getattr_raises_attributeerror():
+    """Check __getattr__ raises AttributeError."""
+    with pytest.raises(AttributeError):
+        fauxfactory.nonexistentattribute


### PR DESCRIPTION
Previous __getattr__ implementation was making use of locals which was
not returning the proper object list as locals in that scope was
returning only objects from the function's scope.

Instead of using globals create a "private" variable to hold all the
factories and make __getattr__ implementation easier.

Also add tests and make sure that __getattr__ implementation returns the
expected objects.