### PR TITLE
Improve execution time of some key methods

### DIFF
--- a/fauxfactory/factories/choices.py
+++ b/fauxfactory/factories/choices.py
@@ -8,6 +8,9 @@ from collections.abc import Iterable
 from fauxfactory.helpers import check_validation
 
 
+random.seed()
+
+
 def gen_choice(choices):
     """Return a random choice from the available choices.
 
@@ -29,7 +32,6 @@ def gen_choice(choices):
     if len(choices) == 1:
         return choices[0]
 
-    random.seed()
     return random.choice(choices)
 
 

--- a/fauxfactory/factories/dates.py
+++ b/fauxfactory/factories/dates.py
@@ -6,6 +6,9 @@ import random
 from fauxfactory.constants import MAX_YEARS, MIN_YEARS
 
 
+random.seed()
+
+
 def gen_date(min_date=None, max_date=None):
     """Return a random date value.
 
@@ -34,8 +37,6 @@ def gen_date(min_date=None, max_date=None):
 
     # Check that max_date is not before min_date
     assert min_date < max_date
-
-    random.seed()
 
     # Pick a day between min and max dates
     diff = max_date - min_date
@@ -74,8 +75,6 @@ def gen_datetime(min_date=None, max_date=None):
     # Check that max_date is not before min_date
     assert min_date < max_date
 
-    random.seed()
-
     # Pick a time between min and max dates
     diff = max_date - min_date
     seconds = random.randint(0, diff.days * 3600 * 24 + diff.seconds)
@@ -89,7 +88,6 @@ def gen_time():
     :returns: A random ``datetime.time`` object.
 
     """
-    random.seed()
     return datetime.time(
         random.randint(0, 23),
         random.randint(0, 59),

--- a/fauxfactory/factories/internet.py
+++ b/fauxfactory/factories/internet.py
@@ -10,6 +10,9 @@ from .choices import gen_choice
 from .strings import gen_alpha
 
 
+random.seed()
+
+
 def gen_domain(name=None, subdomain=None, tlds=None):
     """Generate a random domain name.
 
@@ -96,7 +99,6 @@ def gen_ipaddr(ip3=False, ipv6=False, prefix=()):
     if rng < 0:
         raise ValueError(
             f'Prefix {prefix!r} is too long for this configuration')
-    random.seed()
 
     if ipv6:
         # StackOverflow.com questions: generate-random-ipv6-address
@@ -134,7 +136,6 @@ def gen_mac(delimiter=':', multicast=None, locally=None):
     """
     if delimiter not in [':', '-']:
         raise ValueError(f'Delimiter is not a valid option: {delimiter}')
-    random.seed()
     if multicast is None:
         multicast = bool(random.randint(0, 1))
     if locally is None:
@@ -185,7 +186,6 @@ def gen_netmask(min_cidr=1, max_cidr=31):
             f'max_cidr must be less than {len(VALID_NETMASKS)}, '
             f'but is {max_cidr}'
         )
-    random.seed()
     return VALID_NETMASKS[random.randint(min_cidr, max_cidr)]
 
 

--- a/fauxfactory/factories/strings.py
+++ b/fauxfactory/factories/strings.py
@@ -11,6 +11,9 @@ from fauxfactory.helpers import (
     )
 
 
+random.seed()
+
+
 def gen_string(str_type, length=None, validator=None, default=None, tries=10):
     """Call other string generation methods.
 
@@ -79,13 +82,10 @@ def gen_alpha(length=10, start=None, separator=''):
     :rtype: str
 
     """
-    random.seed()
-    output_string = ''.join(
-        random.choice(string.ascii_letters) for _ in range(length)
-    )
+    output_string = ''.join(random.choices(string.ascii_letters, k=length))
 
     if start:
-        output_string = f'{start}{separator}{output_string}'[0:length]
+        output_string = f'{start}{separator}{output_string}'[:length]
     return output_string
 
 
@@ -101,14 +101,14 @@ def gen_alphanumeric(length=10, start=None, separator=''):
     :rtype: str
 
     """
-    random.seed()
     output_string = ''.join(
-        random.choice(
-            string.ascii_letters + string.digits
-        ) for _ in range(length))
+        random.choices(
+            string.ascii_letters + string.digits, k=length
+        )
+    )
 
     if start:
-        output_string = f'{start}{separator}{output_string}'[0:length]
+        output_string = f'{start}{separator}{output_string}'[:length]
     return output_string
 
 
@@ -126,8 +126,6 @@ def gen_cjk(length=10, start=None, separator=''):
     :rtype: str
 
     """
-    random.seed()
-
     # These should represent the ranges for valid CJK characters
     unicode_block = (
         # CJK Unified Ideographs
@@ -148,9 +146,7 @@ def gen_cjk(length=10, start=None, separator=''):
         for i in range(*code_block):
             output_array.append(i)
 
-    output_string = ''.join(
-        chr(random.choice(output_array)) for _ in range(length)
-    )
+    output_string = ''.join(map(chr, random.choices(output_array, k=length)))
 
     if start:
         output_string = f'{start}{separator}{output_string}'[0:length]
@@ -169,8 +165,6 @@ def gen_cyrillic(length=10, start=None, separator=''):
     :rtype: str
 
     """
-    random.seed()
-
     # Generate codepoints, then convert the codepoints to a string. The
     # valid range of Cyrillic codepoints is 0x0400 - 0x04FF, inclusive.
     codepoints = [random.randint(0x0400, 0x04FF) for _ in range(length)]
@@ -191,7 +185,6 @@ def gen_html(length=10, include_tags=True):
     :rtype: str
 
     """
-    random.seed()
     html_tag = random.choice(HTML_TAGS)
 
     if not include_tags:
@@ -303,10 +296,7 @@ def gen_latin1(length=10, start=None, separator=''):
     for i in range(int(range2[0], 16), int(range2[1], 16)):
         output_array.append(i)
 
-    random.seed()
-    output_string = ''.join(
-        chr(random.choice(output_array)) for _ in range(length)
-    )
+    output_string = ''.join(map(chr, random.choices(output_array, k=length)))
 
     if start:
         output_string = f'{start}{separator}{output_string}'[0:length]
@@ -325,10 +315,7 @@ def gen_numeric_string(length=10, start=None, separator=''):
     :rtype: str
 
     """
-    random.seed()
-    output_string = ''.join(
-        random.choice(string.digits) for _ in range(length)
-    )
+    output_string = ''.join(random.choices(string.digits, k=length))
 
     if start:
         output_string = f'{start}{separator}{output_string}'[0:length]
@@ -354,10 +341,7 @@ def gen_utf8(length=10, smp=True, start=None, separator=''):
 
     """
     UNICODE_LETTERS = list(unicode_letters_generator(smp))
-    random.seed()
-    output_string = ''.join(
-        [random.choice(UNICODE_LETTERS) for _ in range(length)]
-    )
+    output_string = ''.join(random.choices(UNICODE_LETTERS, k=length))
 
     if start:
         output_string = f'{start}{separator}{output_string}'[0:length]
@@ -375,10 +359,7 @@ def gen_special(length=10, start=None, separator=''):
     :returns: A random string made up of special characters.
     :rtype: str
     """
-    random.seed()
-    output_string = ''.join(
-        random.choice(string.punctuation) for _ in range(length)
-    )
+    output_string = ''.join(random.choices(string.punctuation, k=length))
 
     if start:
         output_string = f'{start}{separator}{output_string}'[0:length]

--- a/tests/test_macs.py
+++ b/tests/test_macs.py
@@ -53,8 +53,7 @@ def test_gen_mac_6():
 def test_gen_mac_7():
     """Generate a MAC address using a letter as the delimiter."""
     with pytest.raises(ValueError):
-        gen_mac(
-            delimiter=random.choice(string.ascii_letters))
+        gen_mac(delimiter=random.choice(string.ascii_letters))
 
 
 # pylint: disable=C0103


### PR DESCRIPTION
I changed the random selection of some methods from comprehensions to
uses of random.choices. Most improved by around 15%.
However, gen_cjk saw a 5.5x speedup!

I then took it a bit further by moving random.seed out of each method call
and into the module scope.
This greatly improved the runtime of each changed method.
Additionally, it should still alleviate the original concern solved with #81

Here are the observed performance changes
```
before
======
%timeit fauxfactory.gen_alpha()
16.2 µs ± 495 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
%timeit fauxfactory.gen_alphanumeric()
17.4 µs ± 488 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
%timeit fauxfactory.gen_cjk()
18.8 µs ± 232 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

gen choices
===========
%timeit fauxfactory.gen_alpha()
13.7 µs ± 257 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
%timeit fauxfactory.gen_alphanumeric()
13.6 µs ± 536 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
%timeit fauxfactory.gen_cjk()
3.36 ms ± 224 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

seed once
=========
%timeit fauxfactory.gen_alpha()
2.7 µs ± 186 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
%timeit fauxfactory.gen_alphanumeric()
2.6 µs ± 31.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
%timeit fauxfactory.gen_cjk()
3.33 ms ± 44.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
