### PR TITLE
Add option to disable random seed

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ Contributors
 - Milan Falešník `@mfalesni <https://github.com/mfalesni/>`_
 - Nikhil Dhandre `@digitronik <https://github.com/digitronik/>`_
 - Mike Shriver `@mshriver <https://github.com/mshriver/>`_
+- Lisa Walker `@liwalker-rh <https://github.com/liwalker-rh/>`_

--- a/fauxfactory/factories/choices.py
+++ b/fauxfactory/factories/choices.py
@@ -2,13 +2,15 @@
 
 import random
 import uuid
+import os
 
 from collections.abc import Iterable
 
 from fauxfactory.helpers import check_validation
 
 
-random.seed()
+if 'FAUXFACTORY_DISABLE_SEED_RANDOMIZATION' not in os.environ:
+    random.seed()
 
 
 def gen_choice(choices):

--- a/fauxfactory/factories/dates.py
+++ b/fauxfactory/factories/dates.py
@@ -2,11 +2,13 @@
 
 import datetime
 import random
+import os
 
 from fauxfactory.constants import MAX_YEARS, MIN_YEARS
 
 
-random.seed()
+if 'FAUXFACTORY_DISABLE_SEED_RANDOMIZATION' not in os.environ:
+    random.seed()
 
 
 def gen_date(min_date=None, max_date=None):

--- a/fauxfactory/factories/internet.py
+++ b/fauxfactory/factories/internet.py
@@ -2,6 +2,7 @@
 
 import random
 import re
+import os
 
 from fauxfactory.constants import SCHEMES, SUBDOMAINS, TLDS, VALID_NETMASKS
 from fauxfactory.helpers import check_validation
@@ -10,7 +11,8 @@ from .choices import gen_choice
 from .strings import gen_alpha
 
 
-random.seed()
+if 'FAUXFACTORY_DISABLE_SEED_RANDOMIZATION' not in os.environ:
+    random.seed()
 
 
 def gen_domain(name=None, subdomain=None, tlds=None):

--- a/fauxfactory/factories/numbers.py
+++ b/fauxfactory/factories/numbers.py
@@ -3,6 +3,7 @@
 from functools import partial
 import random
 import sys
+import os
 
 from fauxfactory.helpers import base_repr
 
@@ -35,7 +36,9 @@ def gen_integer(min_value=None, max_value=None):
     if not isinstance(max_value, integer_types) or max_value > _max_value:
         raise ValueError(f'"{max_value}" is not a valid maximum.')
 
-    random.seed()
+    if 'FAUXFACTORY_DISABLE_SEED_RANDOMIZATION' not in os.environ:
+        random.seed()
+    
     value = random.randint(min_value, max_value)
 
     return value

--- a/fauxfactory/factories/strings.py
+++ b/fauxfactory/factories/strings.py
@@ -2,6 +2,7 @@
 
 import random
 import string
+import os
 
 from fauxfactory.constants import HTML_TAGS, LOREM_IPSUM_TEXT
 from fauxfactory.helpers import (
@@ -12,7 +13,8 @@ from fauxfactory.helpers import (
 )
 
 
-random.seed()
+if 'FAUXFACTORY_DISABLE_SEED_RANDOMIZATION' not in os.environ:
+    random.seed()
 
 
 def gen_string(str_type, length=None, validator=None, default=None, tries=10):


### PR DESCRIPTION
This change allows anyone using the repo to disable the option of setting a random module seed. In the SWatch team's test code, we noticed an issue where any library using the random module would end up with a new seed value since it is reset multiple times in this repo. To resolve this, I added a check to look for a certain environment variable so that it can catch this during import and ensure the random seed is not reset when someone wants to disable it.

Jira for reference: [SWATCH-3297](https://issues.redhat.com/browse/SWATCH-3297)